### PR TITLE
Endpoints in the wrong format

### DIFF
--- a/clusters/veritable-prod/alice/cloudagent/values.yaml
+++ b/clusters/veritable-prod/alice/cloudagent/values.yaml
@@ -1,5 +1,5 @@
 label: Alice veritable-cloudagent REST API
-endpoint: ["http://cloudagent-veritable-cloudagent.alice.svc.cluster.local:5002"]
+endpoint: "http://cloudagent-veritable-cloudagent.alice.svc.cluster.local:5002"
 logLevel: trace
 ingress:
   enabled: false

--- a/clusters/veritable-prod/bob/cloudagent/values.yaml
+++ b/clusters/veritable-prod/bob/cloudagent/values.yaml
@@ -1,5 +1,5 @@
 label: Bob veritable-cloudagent REST API
-endpoint: ["http://cloudagent-veritable-cloudagent.bob.svc.cluster.local:5002"]
+endpoint: "http://cloudagent-veritable-cloudagent.bob.svc.cluster.local:5002"
 logLevel: trace
 ingress:
   enabled: false

--- a/clusters/veritable-prod/charlie/cloudagent/values.yaml
+++ b/clusters/veritable-prod/charlie/cloudagent/values.yaml
@@ -1,5 +1,5 @@
 label: Charlie veritable-cloudagent REST API
-endpoint: ["http://cloudagent-veritable-cloudagent.charlie.svc.cluster.local:5002"]
+endpoint: "http://cloudagent-veritable-cloudagent.charlie.svc.cluster.local:5002"
 logLevel: trace
 ingress:
   enabled: false

--- a/clusters/veritable-prod/dave/cloudagent/values.yaml
+++ b/clusters/veritable-prod/dave/cloudagent/values.yaml
@@ -1,5 +1,5 @@
 label: Dave veritable-cloudagent REST API
-endpoint: ["http://cloudagent-veritable-cloudagent.dave.svc.cluster.local:5002"]
+endpoint: "http://cloudagent-veritable-cloudagent.dave.svc.cluster.local:5002"
 logLevel: trace
 ingress:
   enabled: false

--- a/clusters/veritable-prod/eve/cloudagent/values.yaml
+++ b/clusters/veritable-prod/eve/cloudagent/values.yaml
@@ -1,5 +1,5 @@
 label: Eve veritable-cloudagent REST API
-endpoint: ["http://cloudagent-veritable-cloudagent.eve.svc.cluster.local:5002"]
+endpoint: "http://cloudagent-veritable-cloudagent.eve.svc.cluster.local:5002"
 logLevel: trace
 ingress:
   enabled: false


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets

VR-238

## High level description

Incorrect endpoint format

## Detailed description

The cloudagent is expecting a string of comma separated values for endpoints, but we were providing an array as a string.


## Describe alternatives you've considered

Reading my own documentation

## Operational impact

N/A

## Additional context

N/A
