### PR TITLE
Setting up a statefulSet

### DIFF
--- a/clusters/veritable-prod/alice/cloudagent/release.yaml
+++ b/clusters/veritable-prod/alice/cloudagent/release.yaml
@@ -11,7 +11,7 @@ spec:
   releaseName: cloudagent
   chart:
     spec:
-      version: 1.0.8
+      version: 2.0.0
       chart: veritable-cloudagent
       sourceRef:
         kind: HelmRepository

--- a/clusters/veritable-prod/alice/cloudagent/values.yaml
+++ b/clusters/veritable-prod/alice/cloudagent/values.yaml
@@ -13,5 +13,7 @@ postgresql:
     serviceMonitor:
       enabled: true
       namespace: alice
-image:
-  tag: v0.10.26
+ipfs:
+  persistence:
+    size: 5Gi
+    storageClass: managed-csi-premium

--- a/clusters/veritable-prod/bob/cloudagent/release.yaml
+++ b/clusters/veritable-prod/bob/cloudagent/release.yaml
@@ -11,7 +11,7 @@ spec:
   releaseName: cloudagent
   chart:
     spec:
-      version: 1.0.8
+      version: 2.0.0
       chart: veritable-cloudagent
       sourceRef:
         kind: HelmRepository

--- a/clusters/veritable-prod/bob/cloudagent/values.yaml
+++ b/clusters/veritable-prod/bob/cloudagent/values.yaml
@@ -13,5 +13,7 @@ postgresql:
     serviceMonitor:
       enabled: true
       namespace: bob
-image:
-  tag: v0.10.26
+ipfs:
+  persistence:
+    size: 5Gi
+    storageClass: managed-csi-premium

--- a/clusters/veritable-prod/charlie/cloudagent/release.yaml
+++ b/clusters/veritable-prod/charlie/cloudagent/release.yaml
@@ -11,7 +11,7 @@ spec:
   releaseName: cloudagent
   chart:
     spec:
-      version: 1.0.8
+      version: 2.0.0
       chart: veritable-cloudagent
       sourceRef:
         kind: HelmRepository

--- a/clusters/veritable-prod/charlie/cloudagent/values.yaml
+++ b/clusters/veritable-prod/charlie/cloudagent/values.yaml
@@ -13,5 +13,7 @@ postgresql:
     serviceMonitor:
       enabled: true
       namespace: charlie
-image:
-  tag: v0.10.26
+ipfs:
+  persistence:
+    size: 5Gi
+    storageClass: managed-csi-premium

--- a/clusters/veritable-prod/dave/cloudagent/release.yaml
+++ b/clusters/veritable-prod/dave/cloudagent/release.yaml
@@ -11,7 +11,7 @@ spec:
   releaseName: cloudagent
   chart:
     spec:
-      version: 1.0.8
+      version: 2.0.0
       chart: veritable-cloudagent
       sourceRef:
         kind: HelmRepository

--- a/clusters/veritable-prod/dave/cloudagent/values.yaml
+++ b/clusters/veritable-prod/dave/cloudagent/values.yaml
@@ -13,5 +13,7 @@ postgresql:
     serviceMonitor:
       enabled: true
       namespace: dave
-image:
-  tag: v0.10.26
+ipfs:
+  persistence:
+    size: 5Gi
+    storageClass: managed-csi-premium

--- a/clusters/veritable-prod/eve/cloudagent/release.yaml
+++ b/clusters/veritable-prod/eve/cloudagent/release.yaml
@@ -11,7 +11,7 @@ spec:
   releaseName: cloudagent
   chart:
     spec:
-      version: 1.0.8
+      version: 2.0.0
       chart: veritable-cloudagent
       sourceRef:
         kind: HelmRepository

--- a/clusters/veritable-prod/eve/cloudagent/values.yaml
+++ b/clusters/veritable-prod/eve/cloudagent/values.yaml
@@ -13,5 +13,7 @@ postgresql:
     serviceMonitor:
       enabled: true
       namespace: eve
-image:
-  tag: v0.10.26
+ipfs:
+  persistence:
+    size: 5Gi
+    storageClass: managed-csi-premium


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets

VR-238

## High level description

Implements statefulSet

## Detailed description

Switches our deployment of the cloudagent for a statefulSet so the ipfs pod can have persistent storage
Sets a 5GB Data partition for the IPFS data.


## Describe alternatives you've considered

Splitting the IPFS component into its own subchart.

## Operational impact

Replacing a deployment for a statefulSet shouldn't cause any issues

## Additional context

N/A
