### PR TITLE
Adding bootnodeAddress to cloudagents ipfs

### DIFF
--- a/clusters/veritable-prod/bob/cloudagent/release.yaml
+++ b/clusters/veritable-prod/bob/cloudagent/release.yaml
@@ -11,7 +11,7 @@ spec:
   releaseName: cloudagent
   chart:
     spec:
-      version: 2.0.0
+      version: 2.1.0
       chart: veritable-cloudagent
       sourceRef:
         kind: HelmRepository

--- a/clusters/veritable-prod/bob/cloudagent/values.yaml
+++ b/clusters/veritable-prod/bob/cloudagent/values.yaml
@@ -17,3 +17,5 @@ ipfs:
   persistence:
     size: 5Gi
     storageClass: managed-csi-premium
+  initConfig:
+    bootNodeAddress: "/dns4/cloudagent-veritable-cloudagent-0-swarm.alice.svc.cluster.local/tcp/4001/p2p/12D3KooWRj6otqGcQg1TPmpsNMND1H3EQCBcpAAReZnHfsdNz6sS"

--- a/clusters/veritable-prod/charlie/cloudagent/release.yaml
+++ b/clusters/veritable-prod/charlie/cloudagent/release.yaml
@@ -11,7 +11,7 @@ spec:
   releaseName: cloudagent
   chart:
     spec:
-      version: 2.0.0
+      version: 2.1.0
       chart: veritable-cloudagent
       sourceRef:
         kind: HelmRepository

--- a/clusters/veritable-prod/charlie/cloudagent/values.yaml
+++ b/clusters/veritable-prod/charlie/cloudagent/values.yaml
@@ -17,3 +17,5 @@ ipfs:
   persistence:
     size: 5Gi
     storageClass: managed-csi-premium
+  initConfig:
+    bootNodeAddress: "/dns4/cloudagent-veritable-cloudagent-0-swarm.alice.svc.cluster.local/tcp/4001/p2p/12D3KooWRj6otqGcQg1TPmpsNMND1H3EQCBcpAAReZnHfsdNz6sS"

--- a/clusters/veritable-prod/dave/cloudagent/release.yaml
+++ b/clusters/veritable-prod/dave/cloudagent/release.yaml
@@ -11,7 +11,7 @@ spec:
   releaseName: cloudagent
   chart:
     spec:
-      version: 2.0.0
+      version: 2.1.0
       chart: veritable-cloudagent
       sourceRef:
         kind: HelmRepository

--- a/clusters/veritable-prod/dave/cloudagent/values.yaml
+++ b/clusters/veritable-prod/dave/cloudagent/values.yaml
@@ -17,3 +17,5 @@ ipfs:
   persistence:
     size: 5Gi
     storageClass: managed-csi-premium
+  initConfig:
+    bootNodeAddress: "/dns4/cloudagent-veritable-cloudagent-0-swarm.alice.svc.cluster.local/tcp/4001/p2p/12D3KooWRj6otqGcQg1TPmpsNMND1H3EQCBcpAAReZnHfsdNz6sS"

--- a/clusters/veritable-prod/eve/cloudagent/release.yaml
+++ b/clusters/veritable-prod/eve/cloudagent/release.yaml
@@ -11,7 +11,7 @@ spec:
   releaseName: cloudagent
   chart:
     spec:
-      version: 2.0.0
+      version: 2.1.0
       chart: veritable-cloudagent
       sourceRef:
         kind: HelmRepository

--- a/clusters/veritable-prod/eve/cloudagent/values.yaml
+++ b/clusters/veritable-prod/eve/cloudagent/values.yaml
@@ -17,3 +17,5 @@ ipfs:
   persistence:
     size: 5Gi
     storageClass: managed-csi-premium
+  initConfig:
+    bootNodeAddress: "/dns4/cloudagent-veritable-cloudagent-0-swarm.alice.svc.cluster.local/tcp/4001/p2p/12D3KooWRj6otqGcQg1TPmpsNMND1H3EQCBcpAAReZnHfsdNz6sS"


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets

VR-238

## High level description

Sets the cloudagent IPFS bootnode address for all instances

## Detailed description

Sets the cloudagent IPFS bootnode address for all instances and upgrades the cloudagent chart.


## Describe alternatives you've considered

N/A

## Operational impact

Need to delete all the ipfs PVC's

## Additional context

N/A
