### PR TITLE
Bumps chart version and stops using smtpSecure option

### DIFF
--- a/clusters/veritable-prod/alice/ui/release.yaml
+++ b/clusters/veritable-prod/alice/ui/release.yaml
@@ -11,7 +11,7 @@ spec:
   releaseName: ui
   chart:
     spec:
-      version: 1.0.22
+      version: 1.0.23
       chart: veritable-ui
       sourceRef:
         kind: HelmRepository

--- a/clusters/veritable-prod/alice/ui/values.yaml
+++ b/clusters/veritable-prod/alice/ui/values.yaml
@@ -27,7 +27,7 @@ emailTransport: SMTP_EMAIL
 smtpHost: smtp.azurecomm.net
 smtpPort: 587
 emailFromAddress: "alice@vrtbl.com"
-smtpSecure: true
+smtpSecure: false
 smtpCredentials:
   enabled: true
   existingSecret: smtp-credentials

--- a/clusters/veritable-prod/bob/ui/release.yaml
+++ b/clusters/veritable-prod/bob/ui/release.yaml
@@ -11,7 +11,7 @@ spec:
   releaseName: ui
   chart:
     spec:
-      version: 1.0.22
+      version: 1.0.23
       chart: veritable-ui
       sourceRef:
         kind: HelmRepository

--- a/clusters/veritable-prod/bob/ui/values.yaml
+++ b/clusters/veritable-prod/bob/ui/values.yaml
@@ -27,7 +27,7 @@ emailTransport: SMTP_EMAIL
 smtpHost: smtp.azurecomm.net
 smtpPort: 587
 emailFromAddress: "bob@vrtbl.com"
-smtpSecure: true
+smtpSecure: false
 smtpCredentials:
   enabled: true
   existingSecret: smtp-credentials

--- a/clusters/veritable-prod/charlie/ui/release.yaml
+++ b/clusters/veritable-prod/charlie/ui/release.yaml
@@ -11,7 +11,7 @@ spec:
   releaseName: ui
   chart:
     spec:
-      version: 1.0.22
+      version: 1.0.23
       chart: veritable-ui
       sourceRef:
         kind: HelmRepository

--- a/clusters/veritable-prod/charlie/ui/values.yaml
+++ b/clusters/veritable-prod/charlie/ui/values.yaml
@@ -27,7 +27,7 @@ emailTransport: SMTP_EMAIL
 smtpHost: smtp.azurecomm.net
 smtpPort: 587
 emailFromAddress: "charlie@vrtbl.com"
-smtpSecure: true
+smtpSecure: false
 smtpCredentials:
   enabled: true
   existingSecret: smtp-credentials

--- a/clusters/veritable-prod/dave/ui/release.yaml
+++ b/clusters/veritable-prod/dave/ui/release.yaml
@@ -11,7 +11,7 @@ spec:
   releaseName: ui
   chart:
     spec:
-      version: 1.0.22
+      version: 1.0.23
       chart: veritable-ui
       sourceRef:
         kind: HelmRepository

--- a/clusters/veritable-prod/dave/ui/values.yaml
+++ b/clusters/veritable-prod/dave/ui/values.yaml
@@ -27,7 +27,7 @@ emailTransport: SMTP_EMAIL
 smtpHost: smtp.azurecomm.net
 smtpPort: 587
 emailFromAddress: "dave@vrtbl.com"
-smtpSecure: true
+smtpSecure: false
 smtpCredentials:
   enabled: true
   existingSecret: smtp-credentials

--- a/clusters/veritable-prod/eve/ui/release.yaml
+++ b/clusters/veritable-prod/eve/ui/release.yaml
@@ -11,7 +11,7 @@ spec:
   releaseName: ui
   chart:
     spec:
-      version: 1.0.22
+      version: 1.0.23
       chart: veritable-ui
       sourceRef:
         kind: HelmRepository

--- a/clusters/veritable-prod/eve/ui/values.yaml
+++ b/clusters/veritable-prod/eve/ui/values.yaml
@@ -27,7 +27,7 @@ emailTransport: SMTP_EMAIL
 smtpHost: smtp.azurecomm.net
 smtpPort: 587
 emailFromAddress: "eve@vrtbl.com"
-smtpSecure: true
+smtpSecure: false
 smtpCredentials:
   enabled: true
   existingSecret: smtp-credentials


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets

VR-219

## High level description

Disabled smtpSecure option and uses updated image

## Detailed description

disables smtpSecure which is only for use on TLS ports.
uses a fixed version of the image which actually passes through smtp authentication credentials.


## Describe alternatives you've considered

N/A

## Operational impact

N/A

## Additional context

N/A
