### PR TITLE
Fix log level

### DIFF
--- a/clusters/kind-cluster/alice/veritable-cloudagent/values.yaml
+++ b/clusters/kind-cluster/alice/veritable-cloudagent/values.yaml
@@ -1,7 +1,7 @@
 label: "Alice veritable-cloudgent REST API"
 walletkey:
   secret: alice
-logLevel: 2
+logLevel: trace
 endpoint: ["http://alice-veritable-cloudagent.alice.svc.cluster.local:5002/"]
 
 ingress:

--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: bug/fix_kind_log_level
+    branch: main
   url: https://github.com/digicatapult/veritable-flux-infra.git
 
 ---

--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: bug/fix_kind_log_level
   url: https://github.com/digicatapult/veritable-flux-infra.git
 
 ---

--- a/clusters/kind-cluster/bob/veritable-cloudagent/values.yaml
+++ b/clusters/kind-cluster/bob/veritable-cloudagent/values.yaml
@@ -1,7 +1,7 @@
 label: "bob veritable-cloudgent REST API"
 walletkey:
   secret: bob
-logLevel: 2
+logLevel: trace
 endpoint: ["http://bob-veritable-cloudagent.bob.svc.cluster.local:5002/"]
 
 ingress:

--- a/clusters/kind-cluster/charlie/veritable-cloudagent/values.yaml
+++ b/clusters/kind-cluster/charlie/veritable-cloudagent/values.yaml
@@ -1,7 +1,7 @@
 label: "Charlie veritable-cloudgent REST API"
 walletkey:
   secret: charlie
-logLevel: 2
+logLevel: trace
 endpoint: ["http://charlie-veritable-cloudagent.bob.svc.cluster.local:5002/"]
 
 ingress:


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix

## Linked tickets

Kind is failing to bring up the personas due to the expected log level being a string, not an integer. Changing the level to "trace", for example, will resolve the issue and the Kind cluster can be stood up as expected.