### PR TITLE
Add end-to-end Kind workflow

### DIFF
--- a/.github/workflow/test-kind-e2e.yaml
+++ b/.github/workflow/test-kind-e2e.yaml
@@ -1,0 +1,150 @@
+name: test-kind-e2e
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - 'main'
+    paths:
+      - 'clusters/kind-cluster/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  statuses: write
+  checks: write
+
+jobs:
+  kind:
+    if: startsWith(github.head_ref, 'renovate/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+      - name: Install Flux
+        uses: fluxcd/flux2/action@main
+      - name: Init Kind action
+        uses: helm/kind-action@v1.12.0
+        with:
+          cluster_name: sqnc-flux-infra
+          config: ./scripts/kind-cluster-config.yaml
+      - name: Install Flux to cluster
+        run: flux install
+      - name: Configure Git
+        run: |
+          git config user.name ${GITHUB_ACTOR}
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+      - name: Create surrogate branch
+        run: |
+          git checkout -b "kind/${GITHUB_HEAD_REF}"
+      - name: Create source and kustomization
+        if: success()
+        run: |
+          flux create source git flux-system \
+          --url=${{ github.event.repository.html_url }} \
+          --branch=main \
+          --username=${GITHUB_ACTOR} \
+          --password=${{ secrets.GITHUB_TOKEN }}
+          flux create kustomization flux-system \
+          --source=flux-system \
+          --path=./clusters/kind-cluster/base
+      - name: Verify Flux kustomizations
+        run: |
+          kubectl wait -A kustomization -l kustomize.toolkit.fluxcd.io/name=flux-system --for=condition=ready --timeout=10m
+      - name: Verify Helm releases
+        run: |
+          kubectl wait -A helmrelease --all --for=condition=ready --timeout=10m
+      - name: Patch GitOps branch to match PR
+        if: success()
+        run: |
+          surrogate=${GITHUB_HEAD_REF}
+          echo "${surrogate}"
+          git fetch origin "${surrogate}:${surrogate}"
+          git checkout "${surrogate}"
+          sed -i -r "s#(branch:).*#\1 $surrogate#" \
+            ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+          git add ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+          git commit -am "Patch GitOps branch to match PR"
+          git push -u origin $surrogate
+      - name: Reconcile the update
+        if: success()
+        run: |
+          flux suspend kustomization --all
+          flux create source git flux-system \
+          --url=${{ github.event.repository.html_url }} \
+          --branch=${GITHUB_HEAD_REF} \
+          --username=${GITHUB_ACTOR} \
+          --password=${{ secrets.GITHUB_TOKEN }}
+          flux resume kustomization --all
+          message=$(echo ${GITHUB_HEAD_REF}"@sha1:"$(git log -n 1 ${GITHUB_HEAD_REF} --pretty=format:"%H"))
+          kubectl wait kustomization --all --all-namespaces --for='jsonpath={.status.conditions[?(@.type=="Ready")].message}=Applied revision: '"$message" --timeout=10m
+          kubectl get kustomizations -A
+          kubectl wait helmrelease --all --all-namespaces --for=condition=ready --timeout=10m
+          kubectl get helmreleases -A
+      - name: Return GitOps branch to main
+        if: success()
+        run: |
+          sed -i -r "s#(branch:).*#\1 main#" \
+            ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+          git add ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+          git commit -am "Return GitOps branch to main"
+          git push -u origin ${GITHUB_HEAD_REF} && \
+          gh api --method POST -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/check-runs \
+            -f name="gotk-sync.yaml status check" \
+            -f head_sha=$(git log -n 1 ${GITHUB_HEAD_REF} --pretty=format:"%H") \
+            -f status="completed" \
+            -f conclusion="success"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Return to parent branch and delete the surrogate
+        if: success()
+        run: |
+          parent=$(echo ${GITHUB_HEAD_REF} | sed "s#kind/renovate#renovate#" -)
+          echo "${parent}"
+          git checkout "${parent}" && \
+          git branch -D "kind/${parent}"
+      - name: Describe failing pods
+        if: failure()
+        run: |
+          namespaces=$(kubectl get namespaces -A | tail -n +2 | awk '{print $1}')
+          for ns in $(echo $namespaces); do
+            pods=$(kubectl get pods -o jsonpath='{range .items[?(@.status.containerStatuses[-1:].state.waiting)]}{.metadata.name}: {@.status.containerStatuses[*].state.waiting.reason}{"\n"}{end}' -n $ns | tail -n +2 | awk '{print $1}')
+            if [ ! -z "$pods" ]; then
+              for pod in $(echo $pods); do
+                kubectl describe pod $pod -n $ns
+                kubectl logs $pod -n $ns
+              done
+            fi
+          done
+      - name: Debug Flux logs
+        if: failure()
+        run: flux logs --level=debug --all-namespaces
+      - name: Return Flux log errors
+        if: failure()
+        run: flux logs --level=error --all-namespaces
+      - name: Debug Flux controller state
+        if: failure()
+        run: kubectl -n flux-system get all
+      - name: Debug source-controller logs
+        if: failure()
+        run: kubectl -n flux-system logs deploy/source-controller
+      - name: Debug kustomize-controller logs
+        if: failure()
+        run: kubectl -n flux-system logs deploy/kustomize-controller
+      - name: Debug helm-controller logs
+        if: failure()
+        run: kubectl -n flux-system logs deploy/helm-controller
+      - name: Report all resources
+        if: failure()
+        run: flux get all --all-namespaces


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Feature

## Linked tickets

VR-335

## High level description

This PR implements an end-to-end workflow that initialises a Kind cluster with a base set of Veritable components, for the purpose of verifying future changes by the Renovate bot. This workflow diverges from the one used for Sequence in a few key stages, specifically in that it creates a fork of the Renovate working branch, notionally something like `renovate/*`, and prefixes it with `kind/`. This change should reduce the level of noise generated against the parent branch that might otherwise interfere with the functionality of the bot, though the process for debugging the root cause of any failure will largely be unaffected. Auto-merging will be separated from the workflow itself, so that it's handled within the Renovate configuration proper; previously, for Sequence, the merging had been performed in-workflow as an additional step once the Helm releases had been pivoted back to the main and branch.