### PR TITLE
Remove unnecessary fetch/checkout

### DIFF
--- a/.github/workflows/test-kind-e2e.yaml
+++ b/.github/workflows/test-kind-e2e.yaml
@@ -69,8 +69,6 @@ jobs:
         run: |
           surrogate="kind/${GITHUB_HEAD_REF}"
           echo "${surrogate}"
-          git fetch origin "${surrogate}:${surrogate}"
-          git checkout "${surrogate}"
           sed -i -r "s#(branch:).*#\1 $surrogate#" \
             ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
           git add ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## High level description

We're checking out the branch twice in succession, though nothing's been pushed yet. As a result, the workflow breaks. Removing the fetch/checkout of the non-existent branch should resolve the issue.