### PR TITLE
Fix alice bootstrap id

### DIFF
--- a/clusters/veritable-prod/bob/cloudagent/values.yaml
+++ b/clusters/veritable-prod/bob/cloudagent/values.yaml
@@ -18,4 +18,4 @@ ipfs:
     size: 5Gi
     storageClass: managed-csi-premium
   initConfig:
-    bootNodeAddress: "/dns4/cloudagent-veritable-cloudagent-0-swarm.alice.svc.cluster.local/tcp/4001/p2p/12D3KooWRj6otqGcQg1TPmpsNMND1H3EQCBcpAAReZnHfsdNz6sS"
+    bootNodeAddress: "/dns4/cloudagent-veritable-cloudagent-0-swarm.alice.svc.cluster.local/tcp/4001/p2p/12D3KooWGnmQExB4qMBiVk1LkcEGG4xGpk9vDEpHC444NVAjq1jq"

--- a/clusters/veritable-prod/charlie/cloudagent/values.yaml
+++ b/clusters/veritable-prod/charlie/cloudagent/values.yaml
@@ -18,4 +18,4 @@ ipfs:
     size: 5Gi
     storageClass: managed-csi-premium
   initConfig:
-    bootNodeAddress: "/dns4/cloudagent-veritable-cloudagent-0-swarm.alice.svc.cluster.local/tcp/4001/p2p/12D3KooWRj6otqGcQg1TPmpsNMND1H3EQCBcpAAReZnHfsdNz6sS"
+    bootNodeAddress: "/dns4/cloudagent-veritable-cloudagent-0-swarm.alice.svc.cluster.local/tcp/4001/p2p/12D3KooWGnmQExB4qMBiVk1LkcEGG4xGpk9vDEpHC444NVAjq1jq"

--- a/clusters/veritable-prod/dave/cloudagent/values.yaml
+++ b/clusters/veritable-prod/dave/cloudagent/values.yaml
@@ -18,4 +18,4 @@ ipfs:
     size: 5Gi
     storageClass: managed-csi-premium
   initConfig:
-    bootNodeAddress: "/dns4/cloudagent-veritable-cloudagent-0-swarm.alice.svc.cluster.local/tcp/4001/p2p/12D3KooWRj6otqGcQg1TPmpsNMND1H3EQCBcpAAReZnHfsdNz6sS"
+    bootNodeAddress: "/dns4/cloudagent-veritable-cloudagent-0-swarm.alice.svc.cluster.local/tcp/4001/p2p/12D3KooWGnmQExB4qMBiVk1LkcEGG4xGpk9vDEpHC444NVAjq1jq"

--- a/clusters/veritable-prod/eve/cloudagent/values.yaml
+++ b/clusters/veritable-prod/eve/cloudagent/values.yaml
@@ -18,4 +18,4 @@ ipfs:
     size: 5Gi
     storageClass: managed-csi-premium
   initConfig:
-    bootNodeAddress: "/dns4/cloudagent-veritable-cloudagent-0-swarm.alice.svc.cluster.local/tcp/4001/p2p/12D3KooWRj6otqGcQg1TPmpsNMND1H3EQCBcpAAReZnHfsdNz6sS"
+    bootNodeAddress: "/dns4/cloudagent-veritable-cloudagent-0-swarm.alice.svc.cluster.local/tcp/4001/p2p/12D3KooWGnmQExB4qMBiVk1LkcEGG4xGpk9vDEpHC444NVAjq1jq"


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix
- [ ] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/VR-363

## High level description

Fixes the id for alice in the bootstrap config for IPFS

## Detailed description

It looks like the IPFS PVs were deleted 14 days ago which caused alice's id to change. This has effectively broken the bootstrap config of the nodes. I believe looking at the chart that modifying this value should result in it being replaced. If not we'll have to change the chart but I don't think this can do any damage


## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
