### PR TITLE
Add PostgreSQL secrets to prod

### DIFF
--- a/clusters/veritable-prod/alice/cloudagent/release.yaml
+++ b/clusters/veritable-prod/alice/cloudagent/release.yaml
@@ -27,3 +27,7 @@ spec:
       name: alice-wallet-key
       valuesKey: key
       targetPath: walletKey.secret
+    - kind: Secret
+      name: alice-cloudagent-postgres-creds
+      valuesKey: password
+      targetPath: postgresql.auth.password

--- a/clusters/veritable-prod/alice/ui/release.yaml
+++ b/clusters/veritable-prod/alice/ui/release.yaml
@@ -43,3 +43,7 @@ spec:
       name: admin-email-address
       valuesKey: address
       targetPath: emailAdminAddress
+    - kind: Secret
+      name: alice-ui-postgres-creds
+      valuesKey: password
+      targetPath: postgresql.auth.password

--- a/clusters/veritable-prod/bob/cloudagent/release.yaml
+++ b/clusters/veritable-prod/bob/cloudagent/release.yaml
@@ -27,3 +27,7 @@ spec:
       name: bob-wallet-key
       valuesKey: key
       targetPath: walletKey.secret
+    - kind: Secret
+      name: bob-cloudagent-postgres-creds
+      valuesKey: password
+      targetPath: postgresql.auth.password

--- a/clusters/veritable-prod/bob/ui/release.yaml
+++ b/clusters/veritable-prod/bob/ui/release.yaml
@@ -43,3 +43,7 @@ spec:
       name: admin-email-address
       valuesKey: address
       targetPath: emailAdminAddress
+    - kind: Secret
+      name: bob-ui-postgres-creds
+      valuesKey: password
+      targetPath: postgresql.auth.password

--- a/clusters/veritable-prod/charlie/cloudagent/release.yaml
+++ b/clusters/veritable-prod/charlie/cloudagent/release.yaml
@@ -27,3 +27,7 @@ spec:
       name: charlie-wallet-key
       valuesKey: key
       targetPath: walletKey.secret
+    - kind: Secret
+      name: charlie-cloudagent-postgres-creds
+      valuesKey: password
+      targetPath: postgresql.auth.password

--- a/clusters/veritable-prod/charlie/ui/release.yaml
+++ b/clusters/veritable-prod/charlie/ui/release.yaml
@@ -43,3 +43,7 @@ spec:
       name: admin-email-address
       valuesKey: address
       targetPath: emailAdminAddress
+    - kind: Secret
+      name: charlie-ui-postgres-creds
+      valuesKey: password
+      targetPath: postgresql.auth.password

--- a/clusters/veritable-prod/dave/cloudagent/release.yaml
+++ b/clusters/veritable-prod/dave/cloudagent/release.yaml
@@ -27,3 +27,7 @@ spec:
       name: dave-wallet-key
       valuesKey: key
       targetPath: walletKey.secret
+    - kind: Secret
+      name: dave-cloudagent-postgres-creds
+      valuesKey: password
+      targetPath: postgresql.auth.password

--- a/clusters/veritable-prod/dave/ui/release.yaml
+++ b/clusters/veritable-prod/dave/ui/release.yaml
@@ -43,3 +43,7 @@ spec:
       name: admin-email-address
       valuesKey: address
       targetPath: emailAdminAddress
+    - kind: Secret
+      name: dave-ui-postgres-creds
+      valuesKey: password
+      targetPath: postgresql.auth.password

--- a/clusters/veritable-prod/eve/cloudagent/release.yaml
+++ b/clusters/veritable-prod/eve/cloudagent/release.yaml
@@ -27,3 +27,7 @@ spec:
       name: eve-wallet-key
       valuesKey: key
       targetPath: walletKey.secret
+    - kind: Secret
+      name: eve-cloudagent-postgres-creds
+      valuesKey: password
+      targetPath: postgresql.auth.password

--- a/clusters/veritable-prod/eve/ui/release.yaml
+++ b/clusters/veritable-prod/eve/ui/release.yaml
@@ -43,3 +43,7 @@ spec:
       name: admin-email-address
       valuesKey: address
       targetPath: emailAdminAddress
+    - kind: Secret
+      name: eve-ui-postgres-creds
+      valuesKey: password
+      targetPath: postgresql.auth.password

--- a/clusters/veritable-prod/secrets/alice-cloudagent-postgres-creds.yaml
+++ b/clusters/veritable-prod/secrets/alice-cloudagent-postgres-creds.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:M0jXjnqLEALJFIS0rk5XKTki2m8AM41e,iv:Ahw7Y7c4zRK9Kf0tQEm1fsOVlBj4yMog0rq0XvJqWA0=,tag:zcZWXl96pOt0ZfXNh2isdw==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: alice-cloudagent-postgres-creds
+    namespace: alice
+sops:
+    lastmodified: "2025-07-15T08:41:37Z"
+    mac: ENC[AES256_GCM,data:oytknElZQaaFFWE9p1TZD8XvWCAL11S1BoYHvgDufge5UJ+H2X+vEEEqIfJrFN1STLBJBo7h1ptQlme0Lldl5UheGWxnS/14QTRAyvpEqDzxe4CaoDPO29ssxQMrfa3WP6Rzo53tfSY5sGGMRX47bmmVoZreYtQGNh4ahXgaKTA=,iv:1TwZzO29NjzhjCkxgWpr3L1PcFjcqyBLks4TZYstKQE=,tag:ikOXPz4369qwzlbUJOBytw==,type:str]
+    pgp:
+        - created_at: "2025-07-15T08:41:37Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4Dnkn8tt10QEQSAQdAKJ6zq5kXmBFtGt7H+s086ilkPRAm/b2IwbMWAWDR/yUw
+            WIlcWqa6ohELQgCr3oGS/oKJhH1uu2GSNynYy5i1zIMMN+FIOh5bKb1uqxRQUZF5
+            1GgBCQIQZDiSqzvrLChCp8Cb/ts1u7q6rrwH1g+QEj0oRKurTsiZXg6lGOYYCrGu
+            QoFygFc6BUV1koXmgEpk15NnpOKy4WoLUjAV7acau4dQuGNEsTgJmpPNzO6/Rzg8
+            fBxN8ztYwSQHhA==
+            =QQFX
+            -----END PGP MESSAGE-----
+          fp: 4A6351B3CE46129AA516AF77DAF4C53DA4A9B16C
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/clusters/veritable-prod/secrets/alice-ui-postgres-creds.yaml
+++ b/clusters/veritable-prod/secrets/alice-ui-postgres-creds.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:wG316eVt68Hq9bjmJSpbjt6L9P6tWaJf,iv:opeGinQqBDTedcLdWULMLKXqyZ5/36UDBF2SODL82hE=,tag:p+QZ/X98knaLlm9ZpW5Uzw==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: alice-ui-postgres-creds
+    namespace: alice
+sops:
+    lastmodified: "2025-07-15T08:41:37Z"
+    mac: ENC[AES256_GCM,data:NvyrWhJ/d3J1vstt0K3eDFWNRZtNdaNijarpi8OTzSqw7oMXfV783jdvrA9qUwTiGT3GeQJYeAnZlmaSFg/nlKHtkBJ1W2ZPOAVI7EIKjSV3zGRA0HJyBq71hmVWFRf+48kDdlJPNoo1G9X8AVDsihdq3rm24kfO/tADy07TfEo=,iv:bmpnsCaRhKa2Z4LV6IIODSZQCe7ylD1hvNyKkeczmzE=,tag:ZsWGoxk/fnOoCKl3NLwsFw==,type:str]
+    pgp:
+        - created_at: "2025-07-15T08:41:37Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4Dnkn8tt10QEQSAQdA1oPOavXlFDw2L9gTbxjcDfmlSNb5vf3iioyGwHaY+1ww
+            u2tFEM7XW6kuH3TAt6Qjb7yUW1JA70ByjdIFuqrbuJlGJRKxgDvnQ8K2DFKptycT
+            1GgBCQIQNAy6FgqNtPbUdWvG9gUl5X70w/Qt1UlbRWIDE6KxccWOHthCO/0m7aQm
+            GOxZ13C8LhJb+tQi+kE3LN47CWY39dgK1uqt/bv7LQAfBMLpfba1OLxcns8vn6Ft
+            ePAkC/XhH19eOw==
+            =l9SN
+            -----END PGP MESSAGE-----
+          fp: 4A6351B3CE46129AA516AF77DAF4C53DA4A9B16C
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/clusters/veritable-prod/secrets/bob-cloudagent-postgres-creds.yaml
+++ b/clusters/veritable-prod/secrets/bob-cloudagent-postgres-creds.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:Cm7Vc9gR1roYtJzfxdGiaoKEyq2c82i8,iv:g3TzSu2ukc1vbYljvlZ/UJg5NCd9uFsmjaDEY4cPE2k=,tag:Ty1JIbQQ0oJJTKB8dH8uiA==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: bob-cloudagent-postgres-creds
+    namespace: bob
+sops:
+    lastmodified: "2025-07-15T08:41:38Z"
+    mac: ENC[AES256_GCM,data:c1ajZxxM4AGHY9MdAA2iYgvFRTiuBcepExKJnINTEz2D/LHerkN0ZBNqO4m0lIC1RcTZyhseAoA6SMOtIksDZXlAMezJLD7LFAkIwliCeh3lzOcEtKwQi/n+/riKJKmQxxZctWrkKFDcTviS0DIdNgonX8U5QsGvg9MN5P5ABLU=,iv:iuWfjL/PDg8fFbXeS3MeQoB1BsHEftr3UbI15hMMBMI=,tag:4ObmnTB+hSlq2Z33Uo7sSA==,type:str]
+    pgp:
+        - created_at: "2025-07-15T08:41:38Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4Dnkn8tt10QEQSAQdAhF/t4lsT6Hr58+Kfnid1RhFPK6VUbmEChEz/zAU0AD4w
+            21mQc+fFCJpOTXr25EABK4hLgnkUN0aCE2+S/kRLwioMDAWtqgjTrlBqNphO3GVq
+            1GYBCQIQlPD2OXa1HdatS/hj6FdWiHgPHjeousXQGcFqel5li10zqOozjxNidq8R
+            NLhhr27U7ic0k2iVZoy20zQ/ePgFOB/2Uav60OD6cYCl1Dqhnx71ps6+H+vrQzrm
+            KUq8p70hMko=
+            =ZUpU
+            -----END PGP MESSAGE-----
+          fp: 4A6351B3CE46129AA516AF77DAF4C53DA4A9B16C
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/clusters/veritable-prod/secrets/bob-ui-postgres-creds.yaml
+++ b/clusters/veritable-prod/secrets/bob-ui-postgres-creds.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:xkrYWkM1kkuboSmwKq5rTVVSbJZuIDpb,iv:LZItQWcId+I8dJ8o0cbztn2TI0fyKcqgkbRYEWxmEkM=,tag:M99PU4RcZJwZcOdflIT4Hw==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: bob-ui-postgres-creds
+    namespace: bob
+sops:
+    lastmodified: "2025-07-15T08:41:38Z"
+    mac: ENC[AES256_GCM,data:aTAhemEtVXVWYAsUIE5p34CZzA+jGDx8Q4s2eMlu/uAiRgOgztASmmVu+Jmq5wPPm2vT5lplVTzDXHFDIzO5KGLEu95LCLP72EoH90//40s20gZSOxqEhtLuZ+Vqu9IBE9UPkilnRSRCk8wrNT98XnQzPfbjcDXgamFTbOPW570=,iv:sjLIhGF9J39d1FQAkXuSx4NQJJU/BcJgX1JUgXoTS44=,tag:x+p9hG+HvZjN9Fd/6nLwJA==,type:str]
+    pgp:
+        - created_at: "2025-07-15T08:41:38Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4Dnkn8tt10QEQSAQdACzzUlfmDx9vtU916GLjzC67v7vwnjG4xAbO6CO2+fxAw
+            hLS61YlfAZD5QF7/kwE4tRljzQtq/kaY4zYQRX7kAe3hp77pNtGPGaxpZ/xF+RWL
+            1GgBCQIQ6/kF9sbutMRevfC372rUeDqKv/Ahn+GNBZsjIsCsW4IiILeE8giNKOkq
+            Eukwu5MtbKqvrxouUDmDjL36p288mWgSSlOlQQ9BoRA4MHR1Ls9mLzJhXf31gl/a
+            DivwRKX2IWeuAQ==
+            =F0qM
+            -----END PGP MESSAGE-----
+          fp: 4A6351B3CE46129AA516AF77DAF4C53DA4A9B16C
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/clusters/veritable-prod/secrets/charlie-cloudagent-postgres-creds.yaml
+++ b/clusters/veritable-prod/secrets/charlie-cloudagent-postgres-creds.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:Mt7kclM1O6EUXztkV9MRGwI5c/vYIru0,iv:iCEQF0lHOptsWEQaDAMIa97cPO0YPtYjT5rJSojgmdc=,tag:KIFAyynw5UBpWbYmAGiKGg==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: charlie-cloudagent-postgres-creds
+    namespace: charlie
+sops:
+    lastmodified: "2025-07-15T08:41:38Z"
+    mac: ENC[AES256_GCM,data:kU/H+rYq9/GtzDMs/V4QNans4+/58IJUkJpaldmuke3grRjgVhAZg8w0JReCAdeNo8pijVeiH9xO9OzvF8mCJnqfAUZlzm8Iy1jUvvD93LyccDeMSVzpaXSRs/pXIIo2mMj26achYIjdp1+dh9YbvunFnElS5uO9Z9mP1QmspKg=,iv:h5aWKgpDYaMyRoAFzsPrWZnuy7f+xgxV1qPavEpb8tQ=,tag:NhaPk4v7n4cRl5YzuapzRQ==,type:str]
+    pgp:
+        - created_at: "2025-07-15T08:41:38Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4Dnkn8tt10QEQSAQdAJ8GrN3WFoHEI2aID2IgAWUlhqAjyQkbmuYAjo0uGiF8w
+            Z6O3tlHYCJz2QhHukJnXogMz2vJZospI31x+zz1hRwp2nFX8kMei4S+vzwPLyfnZ
+            1GgBCQIQHASHiZLfK30jkfQ4WGDN+0xt03UQ5nsrHIPGqrisdU01aqI0c4Ves0H3
+            e54z30LzM4b7yoRMGEnQb+sTffKEMmkopMDAljasXdGz+bRR02+SWUpq/yV8Gz6i
+            d0WOeN0grRoPJQ==
+            =3a0C
+            -----END PGP MESSAGE-----
+          fp: 4A6351B3CE46129AA516AF77DAF4C53DA4A9B16C
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/clusters/veritable-prod/secrets/charlie-ui-postgres-creds.yaml
+++ b/clusters/veritable-prod/secrets/charlie-ui-postgres-creds.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:pm3UT3h5zp6e6mNXB0jyx2PvuKEWjPYu,iv:YUDNu8Pl2TwFcpeuBdZozfdk9RxGKcm8dtwc6csYkoU=,tag:nEnN1LTPJgYJDVhKB1kirA==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: charlie-ui-postgres-creds
+    namespace: charlie
+sops:
+    lastmodified: "2025-07-15T08:41:38Z"
+    mac: ENC[AES256_GCM,data:WfxlhOpSGRL7DQuzoLpyxEUqrYVFjccLTxtCRkFHHA/tCzZQxR9N0YWly3O3C2w8a6VGm3eVQyr5cfbY619PtsL3g7N4o3CVwEY50ODfh9EqoVQA+dkTHDz9X+dlU4c5GImnfk2xZyEB/AfxBSu2VXH5uQTEtUOiafJ57FiwL4Y=,iv:EczVAOl2C/B9grxolP1AwAVaEqxTL+o2FhM+nLy02bo=,tag:vDjCd0tGsLTLrWuwZlUEqQ==,type:str]
+    pgp:
+        - created_at: "2025-07-15T08:41:38Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4Dnkn8tt10QEQSAQdAvoT2uUvB8JTZfZYHAT98es/qb/2uJibgoaDYdbKUXAEw
+            46Pq3/82kWpMh7D1IB/PHDZgcnCzw22VIQH4TxAZM0QQCM5UZrmd7V85vw4TFC58
+            1GYBCQIQ86SPKYzm/bAXCBKNQg8Z+fAvFM5ssRIOjD/wHt4i+aYAVUZ93NX8KxMA
+            e6zmgKdFQVhXbZRJtpTbXkCZeXCdG6c/ata2rVdNQKTEvboDIPrFdiBFN5gXgshG
+            u+zm9nhSxDI=
+            =QzK2
+            -----END PGP MESSAGE-----
+          fp: 4A6351B3CE46129AA516AF77DAF4C53DA4A9B16C
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/clusters/veritable-prod/secrets/dave-cloudagent-postgres-creds.yaml
+++ b/clusters/veritable-prod/secrets/dave-cloudagent-postgres-creds.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:jJv4uc4AVA7G2m0PcXQbVs0ey0b/AE82,iv:vUZffTpAthXUiUSkechLawFXXG8mGrqFsj1y0Ghu90I=,tag:bKHvZ9lrY4se1FiPcdwP2w==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: dave-cloudagent-postgres-creds
+    namespace: dave
+sops:
+    lastmodified: "2025-07-15T08:41:38Z"
+    mac: ENC[AES256_GCM,data:BmpIqcCK98AxEsmHKGFcdsApn79knggCnRY7QVzdMkDotjhzLBt2KCRa03C0OigjDh6yHC9XsIIbT8VTRlNCn5EOMhYO6yvjby3XBtFSe5dytyuJdeDUVDd5sE/8ESuyBLc9XqL6ODR8FH2vBFV9DbvZV02EZ4kpgYyqVuEgn3E=,iv:ZVzC3jb9fQUWbCN75DzR9odzYm9YeKAWsgbjj21EDQM=,tag:UePbiQREgBnv3JYQ2Qw7dQ==,type:str]
+    pgp:
+        - created_at: "2025-07-15T08:41:38Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4Dnkn8tt10QEQSAQdAkKB2CxPUwFEmvJW3SCWWxw1Ob+mCMo2Z4usOzyLOzDcw
+            u5eJt5H0wm3DxoOsc72idxZgCiKiWbo88lC3HFqzTV4btcxbEyqmzTBHFhvOvJys
+            1GgBCQIQoH2Zd7WJDo2k1m1zxAgs2VPr/tnoF8Bp6iP/D5rrEE2B5pxAFZLSmDh8
+            JMrR5499tKioF8Ci7sly6NzsU1OsYqvniyeue71coe41txj3UujJPjCXGKNwIAp7
+            Y2zbpMzZYvrwNA==
+            =toKB
+            -----END PGP MESSAGE-----
+          fp: 4A6351B3CE46129AA516AF77DAF4C53DA4A9B16C
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/clusters/veritable-prod/secrets/dave-ui-postgres-creds.yaml
+++ b/clusters/veritable-prod/secrets/dave-ui-postgres-creds.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:WMtb89lylC8vvIuqr/qolX2RxJRALO7P,iv:dZoPGCV17e+ffIJ2pcZVGxpvJxaUKKmpkpIBqXWxsWk=,tag:rseOiUfHB27p7G1l1c9Qpg==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: dave-ui-postgres-creds
+    namespace: dave
+sops:
+    lastmodified: "2025-07-15T08:41:38Z"
+    mac: ENC[AES256_GCM,data:WnYIh8fymdCYcM8y0K316rSpIjyfmpmI05u2A/pk352WgproNqy4yh+4YxgEme2IrxLee65T5uoGRDd/9lzDsFR1vwRKvASWiE4uncXgfBK+AjEU2LlmElMGC+bdy+qUSV19JTjK20hRbcnYqzAozioZVbirwJZZkGoH28Rqdqs=,iv:uOeBqY2UOvcS01S2sU/M+Q6egSyxzmuEQxLwZONYDj0=,tag:0fQxfMYMhUD0r2/QU/kgkw==,type:str]
+    pgp:
+        - created_at: "2025-07-15T08:41:38Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4Dnkn8tt10QEQSAQdA41XMe9b7e4tCYeCqFVZmTx6v0FsGlExNDT+5t9HIXmow
+            FzU0AWaYTdnqXCE2i6aaHmu0ADso65EhATq+1vrnKSr6lORtp9gHQK4QFJ7hWw9l
+            1GYBCQIQ1mze8PkPvyUoOI23bbi5RWdSvmC7YReFxCNY28Vc0l/3mnKtnZfHJE/f
+            X1EyjkciYky6boINuuShDYCAbhFJXJKdLyMT1mmryYH5YJzwvISaZaGANj0eY3YE
+            V4Vcxf9TKjI=
+            =vOEz
+            -----END PGP MESSAGE-----
+          fp: 4A6351B3CE46129AA516AF77DAF4C53DA4A9B16C
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/clusters/veritable-prod/secrets/eve-cloudagent-postgres-creds.yaml
+++ b/clusters/veritable-prod/secrets/eve-cloudagent-postgres-creds.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:TsAvGFqicut97uLakduBrCrbWK0B/p1r,iv:USco1bFQl7Y6r0jNWKTkj9UB0JQO92NyTmIrsPMSYKI=,tag:nrv4Z46gr3ATT7V/OpTC4w==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: eve-cloudagent-postgres-creds
+    namespace: eve
+sops:
+    lastmodified: "2025-07-15T08:41:38Z"
+    mac: ENC[AES256_GCM,data:/VR9G9qePKbZIABJFfLMoxYsXrLFw2XwXbSUibNCmDjjYDigPVXjMrXY+uzHiwbseIdf0mR/5kehMw4Tq0//nzvSApB1TXJRm+6ZgnTfhwIoXgJoiPCXpNNr0PZI3t4mT5MrNcwzDMhloX5qkCtg1hRgkzn9OUb7foQBMtvIUC4=,iv:F16rXch2vYvcfM7zWHuzXPlhfnh8gahepBDI0oHoYWQ=,tag:ioY53xrlW4zVjhjvqKSIlA==,type:str]
+    pgp:
+        - created_at: "2025-07-15T08:41:38Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4Dnkn8tt10QEQSAQdAk6ZwHg0CrFj8O1icuXEcpMQQHhNtVrrD2R/crQe76QQw
+            rXmXyHoymWbHty4Vmt8GaYgyPwuiGuLDkAWZoOdy0+58Ny4DdDeak/XA/aLNDFVX
+            1GgBCQIQHYn9TTQyjKJ4HVyWbWbD2sQU/VNfZeH2YIZkiMdKYIKtXjrVHrrlDsv/
+            1GgKeHJJpIBmhzKea2aSrKjZ9JLhldPLB8nra93XdSp1PC+Brn3SoG1gETSZiqh6
+            Kt5rZpRutEVhjg==
+            =ggXx
+            -----END PGP MESSAGE-----
+          fp: 4A6351B3CE46129AA516AF77DAF4C53DA4A9B16C
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/clusters/veritable-prod/secrets/eve-ui-postgres-creds.yaml
+++ b/clusters/veritable-prod/secrets/eve-ui-postgres-creds.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:8IzpdWmj4vFLvkeDNoxx1iSXD55IqqiT,iv:UZDcfSJ0f1C+r9WuB1cfdBoYw9lG3EiGEEnkYfX+0zk=,tag:xSpFoQLt5bs27RLXOh6XeQ==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: eve-ui-postgres-creds
+    namespace: eve
+sops:
+    lastmodified: "2025-07-15T08:41:38Z"
+    mac: ENC[AES256_GCM,data:yllJtO4szUwkob1Um1UMTA4zaH0fp9zVwLkG9zGfMFVvlon+9opXtOw3YP05TbYaE1WEoZBaAKP5kk9sHpM4pkGCcJ69DC87tRV1hfdHtuxtbZoFHvZc7ZYz8yVxZKFzZjOV7mOWvrutGAE+AUxaO2wJMrnqjQkZDWl16rHAzeM=,iv:10ZU50T/LbBUnykf0IANiKzY9bgFf6xlKECPql1VZdA=,tag:azz9yMWkNX+IyptetcQ59A==,type:str]
+    pgp:
+        - created_at: "2025-07-15T08:41:38Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4Dnkn8tt10QEQSAQdAsFWhrZq17Qs0YKsuL0uBFSTHR2ZgNf0hVSIAzC1z6how
+            qshzbRqEjYAOduz/42d5brFeb5jQuOfrPGar2d1CcrSmX3DkTtgPZsZFVX0UxrEE
+            1GgBCQIQhxy8+Z4k5eh+pzxe6Wg6ANkF3bXEWGzOUa4sdgzgbB3ouxBl6TXu3Wg4
+            zrYgT+mBqFL2Vde3bEap24zln+BZcOCjSAJc44pVH7R0ZXSpjdoBdKfYwG4VzCym
+            PbwLp33GBIWzdg==
+            =YX76
+            -----END PGP MESSAGE-----
+          fp: 4A6351B3CE46129AA516AF77DAF4C53DA4A9B16C
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Feature

## Linked tickets

VR-397

## High level description

We're currently lacking any persistent secrets for the Veritable UI and Cloud Agent backends, making it difficult to recover a working password when a Kubernetes deployment is deleted or when other breaking changes occur and some other intervention is needed. Adding secrets to the PostgreSQL instances should improve general reliability and root cause analysis while also enabling faster recovery times.

## Operational impact

There isn't any impact from the feature itself. This approach is comparable to one used with Sequence, where SOPS-encrypted secrets are effective in ensuring that the various backends are brought up with a persisting secret.