### PR TITLE
Fix the handling of additional repositories

### DIFF
--- a/.github/workflows/test-kind-e2e.yaml
+++ b/.github/workflows/test-kind-e2e.yaml
@@ -87,11 +87,11 @@ jobs:
           flux resume kustomization --all
           message=$(echo ${surrogate}"@sha1:"$(git log -n 1 ${surrogate} --pretty=format:"%H"))
           sets=$(kubectl get kustomizations -A -o jsonpath='{range .items[*]}{@.metadata.namespace}{"#"}{@.metadata.name}{"#"}{@.spec.sourceRef.name}{"\n"}{end}')
-          ignore_set="monitoring-flux-infra"
-          local_sets=$(echo "${sets}" | grep -v $ignore_set)
+          ignore_pattern="monitoring-flux-infra"
+          local_sets=$(echo "${sets}" | grep -v $ignore_pattern)
           for set in $local_sets; do
-            ns=$(echo ${set} | cut -d "#" -f 1 | awk '{print $1}')
-            k=$(echo ${set} | cut -d "#" -f 2 | awk '{print $1}')
+            ns=$(echo ${set} | cut -d "#" -f 1)
+            k=$(echo ${set} | cut -d "#" -f 2)
             kubectl wait kustomization "${k}" -n "${ns}" --for='jsonpath={.status.conditions[?(@.type=="Ready")].message}=Applied revision: '"$message" --timeout=10m
           done
           kubectl get kustomizations -A


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

VR-344

## High level description

Because we switched to sourcing the monitoring stack from an external repository, the revision IDs for those kustomizations will no longer match what's expected for the local branch. In the workflow's patching steps, we call `kubectl` to wait for a message containing the branch name, "SHA1" string, and the short-form version of the commit hash. That hash corresponds to the most recent push against the working branch, but it won't apply to any remote repositories. As a result, `kubectl` waits indefinitely for a message that won't be formatted correctly for the external monitoring stack.

One solution is to include the name of the local GitRepository ("flux-system") in a variable and match against it with the names of any known external repositories ("monitoring-flux-infra"), and then call `kubectl wait` on the remaining selection.