### PR TITLE
Change RE2 patterns to globbing

### DIFF
--- a/renovate.config.js
+++ b/renovate.config.js
@@ -51,7 +51,7 @@ module.exports = (config = {}) => {
         matchManagers: ["flux"],
         matchFileNames: [
           "clusters/veritable-prod/**/*.yaml",
-          "clusters/veritable-prod/**/*.yaml"
+          "clusters/veritable-prod/**/*.yml"
         ],
         matchUpdateTypes: ["minor", "patch", "pin", "digest"],
         separateMajorMinor: true,


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

ENG-177

## High level description

Through a pretty extensive trial-and-error approach to Renovate, we've enabled automerging on the [monitoring-flux-infra](https://github.com/digicatapult/monitoring-flux-infra/commit/2bcfe0d380b42c975398eafc9822139397d9ec4f) repository and PRs there now register correctly as enabled for automerging. That enabling fix differs from this repository in its use of file globbing with `**/*` over RE2. Both pattern matching strategies appear to be supported in Renovate's documentation for `matchFileNames`, but in practice we've eliminated so many other options. It seems logical to change it here and see.