### PR TITLE
Disable grouping on Kind PRs

### DIFF
--- a/renovate.config.js
+++ b/renovate.config.js
@@ -43,6 +43,7 @@ module.exports = (config = {}) => {
         separateMajorMinor: true,
         separateMultipleMajor: true,
         separateMinorPatch: false,
+        groupName: null,
         automerge: true,
         addLabels: ["automerge", "kind"],
       },


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore

## High level description

Grouping PRs for Kind increases the likelihood of checks failing and increases the turnaround time to merge individual changes. Disabling the grouping of Kind PRs seems ideal.