### PR TITLE
Add file filtration to pre-commit step

### DIFF
--- a/renovate.config.js
+++ b/renovate.config.js
@@ -39,6 +39,12 @@ module.exports = (config = {}) => {
           "clusters/kind-cluster/**/*.yaml",
           "clusters/kind-cluster/**/*.yml"
         ],
+        postUpgradeTasks: {
+          fileFilters: [
+            "clusters/kind-cluster/**/*.yaml",
+            "clusters/kind-cluster/**/*.yml"
+          ]
+        },
         matchUpdateTypes: ["minor", "patch", "pin", "digest"],
         separateMajorMinor: true,
         separateMultipleMajor: true,
@@ -53,6 +59,12 @@ module.exports = (config = {}) => {
           "clusters/veritable-prod/**/*.yaml",
           "clusters/veritable-prod/**/*.yml"
         ],
+        postUpgradeTasks: {
+          fileFilters: [
+            "clusters/veritable-prod/**/*.yaml",
+            "clusters/veritable-prod/**/*.yml"
+          ]
+        },
         matchUpdateTypes: ["minor", "patch", "pin", "digest"],
         separateMajorMinor: true,
         separateMultipleMajor: true,


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## High level description

When Renovate finishes an upgrade, it searches for any matching packages found by the manager and (if they're not in the list of ignored paths) will include them in the final commit. Judging by the documentation for `fileFilters`, there is one final opportunity post-upgrade to filter the files that get included in the PR. In Renovate's source code, this filtered list aggregates `fileFilters` and `includePaths`. It's hoped that having two filtered lists, one for each cluster, will stop Renovate from merging additional found packages from outside the target directory into a single commit.

For reference, only one insertion was expected:
```
DEBUG: git commit (repository=digicatapult/veritable-flux-infra, baseBranch=main, branch=renovate/keycloak-24.x)
       "deletedFiles": [],
       "ignoredFiles": [],
       "result": {
         "author": null,
         "branch": "renovate/keycloak-24.x",
         "commit": "7302e7252ed5dc74e07376aa8dc58d754938c075",
         "root": false,
         "summary": {"changes": 2, "insertions": 2, "deletions": 2}
       }
```

It was anticipated that there would be two Keycloak PRs, one for each cluster, rather than two files in a single commit.