### PR TITLE
Update prod with overlay for the monitoring stack

### DIFF
--- a/clusters/veritable-prod/base/flux-system/gotk-sync.yaml
+++ b/clusters/veritable-prod/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: bug/add_monitoring_stack_project_overlay_to_production
+    branch: main
   url: https://github.com/digicatapult/veritable-flux-infra.git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/clusters/veritable-prod/base/flux-system/gotk-sync.yaml
+++ b/clusters/veritable-prod/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: bug/add_monitoring_stack_project_overlay_to_production
   url: https://github.com/digicatapult/veritable-flux-infra.git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/clusters/veritable-prod/base/monitoring-infra-sync.yaml
+++ b/clusters/veritable-prod/base/monitoring-infra-sync.yaml
@@ -10,6 +10,11 @@ spec:
       namespace: monitoring
   interval: 10m0s
   path: ./applications
+  postBuild:
+    substitute:
+      ALLOY_VERSION: "1.2.0"
+      KUBE_PROMETHEUS_STACK_VERSION: "71.2.0"
+      LOKI_VERSION: "6.33.0"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/clusters/veritable-prod/base/monitoring-infra-sync.yaml
+++ b/clusters/veritable-prod/base/monitoring-infra-sync.yaml
@@ -5,6 +5,9 @@ metadata:
   name: monitoring-infra-sync
   namespace: monitoring
 spec:
+  dependsOn:
+    - name: project-sync
+      namespace: monitoring
   interval: 10m0s
   path: ./applications
   prune: true
@@ -19,6 +22,9 @@ metadata:
   name: env-sync
   namespace: monitoring
 spec:
+  dependsOn:
+    - name: project-sync
+      namespace: monitoring
   interval: 10m0s
   path: ./clusters/azure/production
   prune: true
@@ -26,7 +32,17 @@ spec:
     kind: GitRepository
     name: monitoring-flux-infra
     namespace: flux-system
-  postBuild:
-    substitute:
-      MONITORING_STACK_HOSTNAME: "monitoring.vrtbl.com"
-      MONITORING_STACK_URL: "https://monitoring.vrtbl.com"
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: project-sync
+  namespace: monitoring
+spec:
+  interval: 10m0s
+  path: ./clusters/veritable-prod/monitoring
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/clusters/veritable-prod/base/sources.yaml
+++ b/clusters/veritable-prod/base/sources.yaml
@@ -8,5 +8,5 @@ spec:
   interval: 1m0s
   ref:
     branch: main
-    semver: ^v3.0.0
+    semver: ^v4.0.0
   url: https://github.com/digicatapult/monitoring-flux-infra.git

--- a/clusters/veritable-prod/base/sources.yaml
+++ b/clusters/veritable-prod/base/sources.yaml
@@ -8,5 +8,5 @@ spec:
   interval: 1m0s
   ref:
     branch: main
-    semver: ^v1.1.0
+    semver: ^v3.0.0
   url: https://github.com/digicatapult/monitoring-flux-infra.git

--- a/clusters/veritable-prod/monitoring/alloy/kustomization.yaml
+++ b/clusters/veritable-prod/monitoring/alloy/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring

--- a/clusters/veritable-prod/monitoring/alloy/values.yaml
+++ b/clusters/veritable-prod/monitoring/alloy/values.yaml
@@ -1,0 +1,1 @@
+# https://github.com/grafana/alloy/blob/main/operations/helm/charts/alloy/values.yaml

--- a/clusters/veritable-prod/monitoring/kube-prometheus-stack/kustomization.yaml
+++ b/clusters/veritable-prod/monitoring/kube-prometheus-stack/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring

--- a/clusters/veritable-prod/monitoring/kube-prometheus-stack/values.yaml
+++ b/clusters/veritable-prod/monitoring/kube-prometheus-stack/values.yaml
@@ -1,0 +1,30 @@
+# https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml
+grafana:
+  env:
+    JAEGER_AGENT_PORT: ""
+  envValueFrom:
+    KEYCLOAK_CLIENT_SECRET:
+      secretKeyRef:
+        name: grafana-client-secret
+        key: grafana-client-secret
+  grafana.ini:
+    server:
+      root_url: https://monitoring.vrtbl.com
+    auth.generic_oauth:
+      enabled: true
+      name: Keycloak
+      allow_sign_up: true
+      scopes: openid,email,profile,offline_access,roles
+      auth_url: https://auth.vrtbl.com/realms/idp-broker/protocol/openid-connect/auth
+      token_url: https://auth.vrtbl.com/realms/idp-broker/protocol/openid-connect/token
+      api_url: https://auth.vrtbl.com/realms/idp-broker/protocol/openid-connect/userinfo
+      client_id: grafana
+      client_secret: "${KEYCLOAK_CLIENT_SECRET}"
+      role_attribute_path: contains(groups[*], 'grafana_admins') && 'Admin' || contains(groups[*], 'grafana_users') && 'Viewer'
+      use_pkce: true
+      use_refresh_token: true
+  ingress:
+    enabled: true
+    hosts:
+      - monitoring.vrtbl.com
+    ingressClassName: nginx-monitoring

--- a/clusters/veritable-prod/monitoring/kustomization.yaml
+++ b/clusters/veritable-prod/monitoring/kustomization.yaml
@@ -3,11 +3,19 @@ kind: Kustomization
 namespace: monitoring
 resources:
   - source.yaml
+  - alloy
+  - kube-prometheus-stack
+  - loki
   - nginx
 configMapGenerator:
   - name: monitoring-values
     files:
       - values-nginx.yaml=nginx/values.yaml
+  - name: project-values
+    files:
+      - alloy-project-values.yaml=alloy/values.yaml
+      - kube-prometheus-stack-project-values.yaml=kube-prometheus-stack/values.yaml
+      - loki-project-values.yaml=loki/values.yaml
 configurations:
   - kustomize-config.yaml
 generatorOptions:

--- a/clusters/veritable-prod/monitoring/loki/kustomization.yaml
+++ b/clusters/veritable-prod/monitoring/loki/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring

--- a/clusters/veritable-prod/monitoring/loki/values.yaml
+++ b/clusters/veritable-prod/monitoring/loki/values.yaml
@@ -1,0 +1,1 @@
+# https://github.com/grafana/loki/blob/main/production/helm/loki/values.yaml

--- a/clusters/veritable-prod/secrets/grafana-client-secret.yaml
+++ b/clusters/veritable-prod/secrets/grafana-client-secret.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+data:
+    grafana-client-secret: ENC[AES256_GCM,data:KnXcQJ65ft7Ikm1r0yqmtOeJkuqtriVq5VD8hbJVVQjuh5mphTOkjSQZgKc=,iv:K4Ax6hvaZmlST3s4/e1CUfuofOk/WoorGZDnNPdjeqs=,tag:x2qnTjEMqQBQTvWdS65BsQ==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: grafana-client-secret
+    namespace: monitoring
+sops:
+    lastmodified: "2025-07-23T11:50:48Z"
+    mac: ENC[AES256_GCM,data:wQH7NQ79DpAEAfxwrES7si/TZzv02P88vIIiWmtkq6f+26Tv2g7fOTtaVjrR9f24yPMP2855W9UD64w+TCXelG5uC7AEO0N9SyszrcEQWIX25s2KSI+/Pmz5XMyGOr4rVAsEqZ+ix44FGmoPm7EfWH1W3simdQIDfVGRQ/KZ8jU=,iv:fyMPc5Sz4ueKlfH9Tx1rNZzCjiSP9Uf8LzQLotl7rOE=,tag:Pq7cQw3SAqmxMIx3+CR16A==,type:str]
+    pgp:
+        - created_at: "2025-07-23T11:50:48Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4Dnkn8tt10QEQSAQdAqvvp0DK9VY9KWGPdZI/fgl/PW5DmrU9QtMh0wzc8NSkw
+            AwyspoP2B8YaB+mCGzzq08L0CgeCRggTaoXfXmlTstlJkX2Ea7VXSOmyAmEBrGAS
+            1FsBCQIQVllcC/hVE7jFr3+5ESpNs2KuBoDsDMKE+CTbnWzTkj8zwO09NVfFsNWt
+            SBc1riM0Ev7TerQnBGYHpSJBiXSqrTkrX6NlbQDHIdXL+70kab+1jqcggCbl
+            =u1SG
+            -----END PGP MESSAGE-----
+          fp: 4A6351B3CE46129AA516AF77DAF4C53DA4A9B16C
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix
- [x] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

VR-408

## High level description

This PR integrates the project-specific overlays for Veritable in production and bumps the source version of the [monitoring-flux-repo](https://github.com/digicatapult/monitoring-flux-infra) to v3.0.0. Whereas the Kind fix in #124 is relatively light-touch, this PR includes hostnames, URIs, and the client secret needed to authenticate requests via Keycloak on behalf of the Grafana client. This ought to allow SSO to be configured for access to the production cluster's Grafana UI.