### PR TITLE
Use Bitnami Legacy images with Kind

### DIFF
--- a/clusters/kind-cluster/alice/veritable-cloudagent/values.yaml
+++ b/clusters/kind-cluster/alice/veritable-cloudagent/values.yaml
@@ -8,17 +8,20 @@ ingress:
 # https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
 # Bitnami Legacy images
 postgresql:
-  # image:
-  #   repository: bitnamilegacy/postgresql
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
   volumePermissions:
     enabled: false
-    # image:
-    #   repository: bitnamilegacy/os-shell
+    image:
+      repository: bitnamilegacy/os-shell
   auth:
     password: postgres
   metrics:
-    # image:
-    #   repository: bitnamilegacy/postgres-exporter
+    image:
+      repository: bitnamilegacy/postgres-exporter
     enabled: true
     serviceMonitor:
       enabled: true

--- a/clusters/kind-cluster/alice/veritable-cloudagent/values.yaml
+++ b/clusters/kind-cluster/alice/veritable-cloudagent/values.yaml
@@ -8,17 +8,17 @@ ingress:
 # https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
 # Bitnami Legacy images
 postgresql:
-  image:
-    repository: bitnamilegacy/postgresql
+  # image:
+  #   repository: bitnamilegacy/postgresql
   volumePermissions:
     enabled: false
-    image:
-      repository: bitnamilegacy/os-shell
+    # image:
+    #   repository: bitnamilegacy/os-shell
   auth:
     password: postgres
   metrics:
-    image:
-      repository: bitnamilegacy/postgres-exporter
+    # image:
+    #   repository: bitnamilegacy/postgres-exporter
     enabled: true
     serviceMonitor:
       enabled: true

--- a/clusters/kind-cluster/alice/veritable-cloudagent/values.yaml
+++ b/clusters/kind-cluster/alice/veritable-cloudagent/values.yaml
@@ -5,10 +5,20 @@ logLevel: trace
 endpoint: ["http://alice-veritable-cloudagent.alice.svc.cluster.local:5002/"]
 ingress:
   enabled: false
+# https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
+# Bitnami Legacy images
 postgresql:
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
   auth:
     password: postgres
   metrics:
+    image:
+      repository: bitnamilegacy/postgres-exporter
     enabled: true
     serviceMonitor:
       enabled: true

--- a/clusters/kind-cluster/alice/veritable-ui/values.yaml
+++ b/clusters/kind-cluster/alice/veritable-ui/values.yaml
@@ -22,17 +22,17 @@ invitationPin:
 # https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
 # Bitnami Legacy images
 postgresql:
-  image:
-    repository: bitnamilegacy/postgresql
+  # image:
+  #   repository: bitnamilegacy/postgresql
   volumePermissions:
     enabled: false
-    image:
-      repository: bitnamilegacy/os-shell
+    # image:
+    #   repository: bitnamilegacy/os-shell
   auth:
     password: postgres
   metrics:
-    image:
-      repository: bitnamilegacy/postgres-exporter
+    # image:
+    #   repository: bitnamilegacy/postgres-exporter
     enabled: true
     serviceMonitor:
       enabled: true

--- a/clusters/kind-cluster/alice/veritable-ui/values.yaml
+++ b/clusters/kind-cluster/alice/veritable-ui/values.yaml
@@ -19,14 +19,28 @@ smtpCredentials:
 invitationPin:
   enabled: true
   secret: secret
+# https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
+# Bitnami Legacy images
 postgresql:
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
   auth:
     password: postgres
   metrics:
+    image:
+      repository: bitnamilegacy/postgres-exporter
     enabled: true
     serviceMonitor:
       enabled: true
       namespace: alice
+      relabelings:
+        - action: replace
+          sourceLabels: [namespace]
+          targetLabel: kubernetes_namespace
 ingress:
   hostname: localhost
   annotations:

--- a/clusters/kind-cluster/alice/veritable-ui/values.yaml
+++ b/clusters/kind-cluster/alice/veritable-ui/values.yaml
@@ -22,17 +22,20 @@ invitationPin:
 # https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
 # Bitnami Legacy images
 postgresql:
-  # image:
-  #   repository: bitnamilegacy/postgresql
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
   volumePermissions:
     enabled: false
-    # image:
-    #   repository: bitnamilegacy/os-shell
+    image:
+      repository: bitnamilegacy/os-shell
   auth:
     password: postgres
   metrics:
-    # image:
-    #   repository: bitnamilegacy/postgres-exporter
+    image:
+      repository: bitnamilegacy/postgres-exporter
     enabled: true
     serviceMonitor:
       enabled: true

--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: chore/use_bitnami_legacy_images_on_kind
   url: https://github.com/digicatapult/veritable-flux-infra.git
 
 ---

--- a/clusters/kind-cluster/base/monitoring-sync.yaml
+++ b/clusters/kind-cluster/base/monitoring-sync.yaml
@@ -10,6 +10,11 @@ spec:
       namespace: monitoring
   interval: 10m0s
   path: ./applications
+  postBuild:
+    substitute:
+      ALLOY_VERSION: "1.2.0"
+      KUBE_PROMETHEUS_STACK_VERSION: "71.2.0"
+      LOKI_VERSION: "6.33.0"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/clusters/kind-cluster/base/sources.yaml
+++ b/clusters/kind-cluster/base/sources.yaml
@@ -8,5 +8,5 @@ spec:
   interval: 1m0s
   ref:
     branch: main
-    semver: ^v3.0.0
+    semver: ^v4.0.0
   url: https://github.com/digicatapult/monitoring-flux-infra.git

--- a/clusters/kind-cluster/bob/veritable-cloudagent/values.yaml
+++ b/clusters/kind-cluster/bob/veritable-cloudagent/values.yaml
@@ -8,17 +8,20 @@ ingress:
 # https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
 # Bitnami Legacy images
 postgresql:
-  # image:
-  #   repository: bitnamilegacy/postgresql
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
   volumePermissions:
     enabled: false
-    # image:
-    #   repository: bitnamilegacy/os-shell
+    image:
+      repository: bitnamilegacy/os-shell
   auth:
     password: postgres
   metrics:
-    # image:
-    #   repository: bitnamilegacy/postgres-exporter
+    image:
+      repository: bitnamilegacy/postgres-exporter
     enabled: true
     serviceMonitor:
       enabled: true

--- a/clusters/kind-cluster/bob/veritable-cloudagent/values.yaml
+++ b/clusters/kind-cluster/bob/veritable-cloudagent/values.yaml
@@ -8,17 +8,17 @@ ingress:
 # https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
 # Bitnami Legacy images
 postgresql:
-  image:
-    repository: bitnamilegacy/postgresql
+  # image:
+  #   repository: bitnamilegacy/postgresql
   volumePermissions:
     enabled: false
-    image:
-      repository: bitnamilegacy/os-shell
+    # image:
+    #   repository: bitnamilegacy/os-shell
   auth:
     password: postgres
   metrics:
-    image:
-      repository: bitnamilegacy/postgres-exporter
+    # image:
+    #   repository: bitnamilegacy/postgres-exporter
     enabled: true
     serviceMonitor:
       enabled: true

--- a/clusters/kind-cluster/bob/veritable-cloudagent/values.yaml
+++ b/clusters/kind-cluster/bob/veritable-cloudagent/values.yaml
@@ -5,10 +5,20 @@ logLevel: trace
 endpoint: ["http://bob-veritable-cloudagent.bob.svc.cluster.local:5002/"]
 ingress:
   enabled: false
+# https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
+# Bitnami Legacy images
 postgresql:
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
   auth:
     password: postgres
   metrics:
+    image:
+      repository: bitnamilegacy/postgres-exporter
     enabled: true
     serviceMonitor:
       enabled: true

--- a/clusters/kind-cluster/charlie/veritable-cloudagent/values.yaml
+++ b/clusters/kind-cluster/charlie/veritable-cloudagent/values.yaml
@@ -5,10 +5,20 @@ logLevel: trace
 endpoint: ["http://charlie-veritable-cloudagent.bob.svc.cluster.local:5002/"]
 ingress:
   enabled: false
+# https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
+# Bitnami Legacy images
 postgresql:
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
   auth:
     password: postgres
   metrics:
+    image:
+      repository: bitnamilegacy/postgres-exporter
     enabled: true
     serviceMonitor:
       enabled: true

--- a/clusters/kind-cluster/charlie/veritable-cloudagent/values.yaml
+++ b/clusters/kind-cluster/charlie/veritable-cloudagent/values.yaml
@@ -8,17 +8,20 @@ ingress:
 # https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
 # Bitnami Legacy images
 postgresql:
-  # image:
-  #   repository: bitnamilegacy/postgresql
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
   volumePermissions:
     enabled: false
-    # image:
-    #   repository: bitnamilegacy/os-shell
+    image:
+      repository: bitnamilegacy/os-shell
   auth:
     password: postgres
   metrics:
-    # image:
-    #   repository: bitnamilegacy/postgres-exporter
+    image:
+      repository: bitnamilegacy/postgres-exporter
     enabled: true
     serviceMonitor:
       enabled: true

--- a/clusters/kind-cluster/charlie/veritable-cloudagent/values.yaml
+++ b/clusters/kind-cluster/charlie/veritable-cloudagent/values.yaml
@@ -8,17 +8,17 @@ ingress:
 # https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
 # Bitnami Legacy images
 postgresql:
-  image:
-    repository: bitnamilegacy/postgresql
+  # image:
+  #   repository: bitnamilegacy/postgresql
   volumePermissions:
     enabled: false
-    image:
-      repository: bitnamilegacy/os-shell
+    # image:
+    #   repository: bitnamilegacy/os-shell
   auth:
     password: postgres
   metrics:
-    image:
-      repository: bitnamilegacy/postgres-exporter
+    # image:
+    #   repository: bitnamilegacy/postgres-exporter
     enabled: true
     serviceMonitor:
       enabled: true

--- a/clusters/kind-cluster/keycloak/values.yaml
+++ b/clusters/kind-cluster/keycloak/values.yaml
@@ -1,5 +1,8 @@
 # https://github.com/bitnami/charts/blob/main/bitnami/keycloak/values.yaml
 # Bitnami Legacy images
+global:
+  security:
+    allowInsecureImages: false
 image:
   repository: bitnamilegacy/keycloak
 keycloakConfigCli:

--- a/clusters/kind-cluster/keycloak/values.yaml
+++ b/clusters/kind-cluster/keycloak/values.yaml
@@ -11,6 +11,8 @@ proxyHeaders: xforwarded
 ingress:
   enabled: true
   hostname: localhost
+# https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
+# Bitnami Legacy images
 postgresql:
   image:
     repository: bitnamilegacy/postgresql

--- a/clusters/kind-cluster/keycloak/values.yaml
+++ b/clusters/kind-cluster/keycloak/values.yaml
@@ -17,6 +17,9 @@ ingress:
 # https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
 # Bitnami Legacy images
 postgresql:
+  global:
+    security:
+      allowInsecureImages: false
   image:
     repository: bitnamilegacy/postgresql
   volumePermissions:

--- a/clusters/kind-cluster/keycloak/values.yaml
+++ b/clusters/kind-cluster/keycloak/values.yaml
@@ -1,3 +1,7 @@
+# https://github.com/bitnami/charts/blob/main/bitnami/keycloak/values.yaml
+# Bitnami Legacy image
+image:
+  repository: bitnamilegacy/keycloak
 httpRelativePath: /auth2/
 proxyHeaders: xforwarded
 ingress:

--- a/clusters/kind-cluster/keycloak/values.yaml
+++ b/clusters/kind-cluster/keycloak/values.yaml
@@ -2,7 +2,7 @@
 # Bitnami Legacy images
 global:
   security:
-    allowInsecureImages: false
+    allowInsecureImages: true
 image:
   repository: bitnamilegacy/keycloak
 keycloakConfigCli:

--- a/clusters/kind-cluster/keycloak/values.yaml
+++ b/clusters/kind-cluster/keycloak/values.yaml
@@ -1,13 +1,27 @@
 # https://github.com/bitnami/charts/blob/main/bitnami/keycloak/values.yaml
-# Bitnami Legacy image
+# Bitnami Legacy images
 image:
   repository: bitnamilegacy/keycloak
+keycloakConfigCli:
+  enabled: false
+  image:
+    repository: bitnamilegacy/keycloak-config-cli
 httpRelativePath: /auth2/
 proxyHeaders: xforwarded
 ingress:
   enabled: true
   hostname: localhost
 postgresql:
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
+  metrics:
+    enabled: false
+    image:
+      repository: bitnamilegacy/postgres-exporter
   auth:
     password: postgres
 extraEnvVars:

--- a/clusters/kind-cluster/nginx/values.yaml
+++ b/clusters/kind-cluster/nginx/values.yaml
@@ -1,5 +1,8 @@
 # https://github.com/bitnami/charts/blob/main/bitnami/nginx-ingress-controller/values.yaml
 # Bitnami Legacy image
+global:
+  security:
+    allowInsecureImages: false
 image:
   repository: bitnamilegacy/nginx-ingress-controller
 defaultBackend:

--- a/clusters/kind-cluster/nginx/values.yaml
+++ b/clusters/kind-cluster/nginx/values.yaml
@@ -1,8 +1,8 @@
 # https://github.com/bitnami/charts/blob/main/bitnami/nginx-ingress-controller/values.yaml
 # Bitnami Legacy image
-# global:
-#   security:
-#     allowInsecureImages: false
+global:
+  security:
+    allowInsecureImages: true
 image:
   repository: bitnamilegacy/nginx-ingress-controller
 defaultBackend:

--- a/clusters/kind-cluster/nginx/values.yaml
+++ b/clusters/kind-cluster/nginx/values.yaml
@@ -1,8 +1,8 @@
 # https://github.com/bitnami/charts/blob/main/bitnami/nginx-ingress-controller/values.yaml
 # Bitnami Legacy image
-global:
-  security:
-    allowInsecureImages: false
+# global:
+#   security:
+#     allowInsecureImages: false
 image:
   repository: bitnamilegacy/nginx-ingress-controller
 defaultBackend:

--- a/clusters/kind-cluster/nginx/values.yaml
+++ b/clusters/kind-cluster/nginx/values.yaml
@@ -2,6 +2,9 @@
 # Bitnami Legacy image
 image:
   repository: bitnamilegacy/nginx-ingress-controller
+defaultBackend:
+  image:
+    repository: bitnamilegacy/nginx
 watchIngressWithoutClass: true
 resourcesPreset: micro
 ingressClassResource:

--- a/clusters/kind-cluster/nginx/values.yaml
+++ b/clusters/kind-cluster/nginx/values.yaml
@@ -1,3 +1,7 @@
+# https://github.com/bitnami/charts/blob/main/bitnami/nginx-ingress-controller/values.yaml
+# Bitnami Legacy image
+image:
+  repository: bitnamilegacy/nginx-ingress-controller
 watchIngressWithoutClass: true
 resourcesPreset: micro
 ingressClassResource:


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore

## Linked tickets

VR-415

## High level description

This PR swaps out the subscription-based Bitnami images for the legacy versions. Around two weeks ago, Bitnami decided to end all on-going support for the open-source images it released based on its own Helm chart library. We've several dependencies that rely on Bitnami components directly and others that use [bitnami/postgresql](https://hub.docker.com/r/bitnami/postgresql) via a sub-chart. These are referenced as repositories within Docker Hub and all need to point instead at the corresponding legacy image, for example: [bitnamilegacy/postgresql](https://hub.docker.com/r/bitnamilegacy/postgresql).

More detail on Bitnami's end-of-life decision for its FOSS images can be found here: [35164](https://github.com/bitnami/charts/issues/35164).

## Operational impact

In addition to the change to the Docker Hub repository, we also need to allow the use of "insecure" images.

Where there's a Bitnami chart used directly, `global.security.allowInsecureImages` should be set at the root of the YAML file:

```yaml
global:
  security:
    allowInsecureImages: true
```

Elsewhere, it should be applied to the PostgreSQL chart via `postgresql.global.security.allowInsecureImages`:

```yaml
postgresql:
  global:
    security:
      allowInsecureImages: true
```