### PR TITLE
Use Bitnami Legacy images on production

### DIFF
--- a/clusters/veritable-prod/alice/cloudagent/values.yaml
+++ b/clusters/veritable-prod/alice/cloudagent/values.yaml
@@ -3,13 +3,25 @@ endpoint: "http://cloudagent-veritable-cloudagent.alice.svc.cluster.local:5002"
 logLevel: trace
 ingress:
   enabled: false
+# https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
+# Bitnami Legacy images
 postgresql:
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
   primary:
     persistence:
       storageClass: managed-csi-premium
       size: 5Gi
   metrics:
     enabled: true
+    image:
+      repository: bitnamilegacy/postgres-exporter
     serviceMonitor:
       enabled: true
       namespace: alice

--- a/clusters/veritable-prod/alice/nginx/values.yaml
+++ b/clusters/veritable-prod/alice/nginx/values.yaml
@@ -1,3 +1,13 @@
+# https://github.com/bitnami/charts/blob/main/bitnami/nginx-ingress-controller/values.yaml
+# Bitnami Legacy image
+global:
+  security:
+    allowInsecureImages: true
+image:
+  repository: bitnamilegacy/nginx-ingress-controller
+defaultBackend:
+  image:
+    repository: bitnamilegacy/nginx
 watchIngressWithoutClass: true
 scope:
   enabled: true

--- a/clusters/veritable-prod/alice/ui/values.yaml
+++ b/clusters/veritable-prod/alice/ui/values.yaml
@@ -10,13 +10,25 @@ externalCloudagent:
   port: "3000"
 invitationFromCompanyNumber: "07964699"
 demoMode: true
+# https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
+# Bitnami Legacy images
 postgresql:
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
   primary:
     persistence:
       storageClass: managed-csi-premium
       size: 5Gi
   metrics:
     enabled: true
+    image:
+      repository: bitnamilegacy/postgres-exporter
     serviceMonitor:
       enabled: true
       namespace: alice

--- a/clusters/veritable-prod/base/flux-system/gotk-sync.yaml
+++ b/clusters/veritable-prod/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: chore/use_bitnami_legacy_images_on_production
+    branch: main
   url: https://github.com/digicatapult/veritable-flux-infra.git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/clusters/veritable-prod/base/flux-system/gotk-sync.yaml
+++ b/clusters/veritable-prod/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: chore/use_bitnami_legacy_images_on_production
   url: https://github.com/digicatapult/veritable-flux-infra.git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/clusters/veritable-prod/bob/cloudagent/values.yaml
+++ b/clusters/veritable-prod/bob/cloudagent/values.yaml
@@ -3,13 +3,25 @@ endpoint: "http://cloudagent-veritable-cloudagent.bob.svc.cluster.local:5002"
 logLevel: trace
 ingress:
   enabled: false
+# https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
+# Bitnami Legacy images
 postgresql:
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
   primary:
     persistence:
       storageClass: managed-csi-premium
       size: 5Gi
   metrics:
     enabled: true
+    image:
+      repository: bitnamilegacy/postgres-exporter
     serviceMonitor:
       enabled: true
       namespace: bob

--- a/clusters/veritable-prod/bob/nginx/values.yaml
+++ b/clusters/veritable-prod/bob/nginx/values.yaml
@@ -1,3 +1,13 @@
+# https://github.com/bitnami/charts/blob/main/bitnami/nginx-ingress-controller/values.yaml
+# Bitnami Legacy image
+global:
+  security:
+    allowInsecureImages: true
+image:
+  repository: bitnamilegacy/nginx-ingress-controller
+defaultBackend:
+  image:
+    repository: bitnamilegacy/nginx
 watchIngressWithoutClass: true
 scope:
   enabled: true

--- a/clusters/veritable-prod/bob/ui/values.yaml
+++ b/clusters/veritable-prod/bob/ui/values.yaml
@@ -10,13 +10,25 @@ externalCloudagent:
   port: "3000"
 invitationFromCompanyNumber: "04659351"
 demoMode: true
+# https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
+# Bitnami Legacy images
 postgresql:
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
   primary:
     persistence:
       storageClass: managed-csi-premium
       size: 5Gi
   metrics:
     enabled: true
+    image:
+      repository: bitnamilegacy/postgres-exporter
     serviceMonitor:
       enabled: true
       namespace: bob

--- a/clusters/veritable-prod/cert-manager/values.yaml
+++ b/clusters/veritable-prod/cert-manager/values.yaml
@@ -1,3 +1,20 @@
+# https://github.com/bitnami/charts/blob/main/bitnami/nginx-ingress-controller/values.yaml
+# Bitnami Legacy image
+global:
+  security:
+    allowInsecureImages: true
+controller:
+  image:
+    repository: bitnamilegacy/cert-manager
+  acmesolver:
+    image:
+      repository: bitnamilegacy/acmesolver
+webhook:
+  image:
+    repository: bitnamilegacy/cert-manager-webhook
+cainjector:
+  image:
+    repository: bitnamilegacy/cainjector
 installCRDs: true
 metrics:
   enabled: true

--- a/clusters/veritable-prod/charlie/cloudagent/values.yaml
+++ b/clusters/veritable-prod/charlie/cloudagent/values.yaml
@@ -3,13 +3,25 @@ endpoint: "http://cloudagent-veritable-cloudagent.charlie.svc.cluster.local:5002
 logLevel: trace
 ingress:
   enabled: false
+# https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
+# Bitnami Legacy images
 postgresql:
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
   primary:
     persistence:
       storageClass: managed-csi-premium
       size: 5Gi
   metrics:
     enabled: true
+    image:
+      repository: bitnamilegacy/postgres-exporter
     serviceMonitor:
       enabled: true
       namespace: charlie

--- a/clusters/veritable-prod/charlie/nginx/values.yaml
+++ b/clusters/veritable-prod/charlie/nginx/values.yaml
@@ -1,3 +1,13 @@
+# https://github.com/bitnami/charts/blob/main/bitnami/nginx-ingress-controller/values.yaml
+# Bitnami Legacy image
+global:
+  security:
+    allowInsecureImages: true
+image:
+  repository: bitnamilegacy/nginx-ingress-controller
+defaultBackend:
+  image:
+    repository: bitnamilegacy/nginx
 watchIngressWithoutClass: true
 scope:
   enabled: true

--- a/clusters/veritable-prod/charlie/ui/values.yaml
+++ b/clusters/veritable-prod/charlie/ui/values.yaml
@@ -10,13 +10,25 @@ externalCloudagent:
   port: "3000"
 invitationFromCompanyNumber: "10016023"
 demoMode: true
+# https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
+# Bitnami Legacy images
 postgresql:
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
   primary:
     persistence:
       storageClass: managed-csi-premium
       size: 5Gi
   metrics:
     enabled: true
+    image:
+      repository: bitnamilegacy/postgres-exporter
     serviceMonitor:
       enabled: true
       namespace: charlie

--- a/clusters/veritable-prod/dave/cloudagent/values.yaml
+++ b/clusters/veritable-prod/dave/cloudagent/values.yaml
@@ -3,13 +3,25 @@ endpoint: "http://cloudagent-veritable-cloudagent.dave.svc.cluster.local:5002"
 logLevel: trace
 ingress:
   enabled: false
+# https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
+# Bitnami Legacy images
 postgresql:
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
   primary:
     persistence:
       storageClass: managed-csi-premium
       size: 5Gi
   metrics:
     enabled: true
+    image:
+      repository: bitnamilegacy/postgres-exporter
     serviceMonitor:
       enabled: true
       namespace: dave

--- a/clusters/veritable-prod/dave/nginx/values.yaml
+++ b/clusters/veritable-prod/dave/nginx/values.yaml
@@ -1,3 +1,13 @@
+# https://github.com/bitnami/charts/blob/main/bitnami/nginx-ingress-controller/values.yaml
+# Bitnami Legacy image
+global:
+  security:
+    allowInsecureImages: true
+image:
+  repository: bitnamilegacy/nginx-ingress-controller
+defaultBackend:
+  image:
+    repository: bitnamilegacy/nginx
 watchIngressWithoutClass: true
 scope:
   enabled: true

--- a/clusters/veritable-prod/dave/ui/values.yaml
+++ b/clusters/veritable-prod/dave/ui/values.yaml
@@ -10,13 +10,25 @@ externalCloudagent:
   port: "3000"
 invitationFromCompanyNumber: "08705784"
 demoMode: true
+# https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
+# Bitnami Legacy images
 postgresql:
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
   primary:
     persistence:
       storageClass: managed-csi-premium
       size: 5Gi
   metrics:
     enabled: true
+    image:
+      repository: bitnamilegacy/postgres-exporter
     serviceMonitor:
       enabled: true
       namespace: dave

--- a/clusters/veritable-prod/eve/cloudagent/values.yaml
+++ b/clusters/veritable-prod/eve/cloudagent/values.yaml
@@ -3,13 +3,25 @@ endpoint: "http://cloudagent-veritable-cloudagent.eve.svc.cluster.local:5002"
 logLevel: trace
 ingress:
   enabled: false
+# https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
+# Bitnami Legacy images
 postgresql:
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
   primary:
     persistence:
       storageClass: managed-csi-premium
       size: 5Gi
   metrics:
     enabled: true
+    image:
+      repository: bitnamilegacy/postgres-exporter
     serviceMonitor:
       enabled: true
       namespace: eve

--- a/clusters/veritable-prod/eve/nginx/values.yaml
+++ b/clusters/veritable-prod/eve/nginx/values.yaml
@@ -1,3 +1,13 @@
+# https://github.com/bitnami/charts/blob/main/bitnami/nginx-ingress-controller/values.yaml
+# Bitnami Legacy image
+global:
+  security:
+    allowInsecureImages: true
+image:
+  repository: bitnamilegacy/nginx-ingress-controller
+defaultBackend:
+  image:
+    repository: bitnamilegacy/nginx
 watchIngressWithoutClass: true
 scope:
   enabled: true

--- a/clusters/veritable-prod/eve/ui/values.yaml
+++ b/clusters/veritable-prod/eve/ui/values.yaml
@@ -10,13 +10,25 @@ externalCloudagent:
   port: "3000"
 invitationFromCompanyNumber: "11837978"
 demoMode: true
+# https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
+# Bitnami Legacy images
 postgresql:
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
   primary:
     persistence:
       storageClass: managed-csi-premium
       size: 5Gi
   metrics:
     enabled: true
+    image:
+      repository: bitnamilegacy/postgres-exporter
     serviceMonitor:
       enabled: true
       namespace: eve

--- a/clusters/veritable-prod/keycloak/keycloak/values.yaml
+++ b/clusters/veritable-prod/keycloak/keycloak/values.yaml
@@ -1,3 +1,13 @@
+# https://github.com/bitnami/charts/blob/main/bitnami/keycloak/values.yaml
+# Bitnami Legacy images
+global:
+  security:
+    allowInsecureImages: true
+image:
+  repository: bitnamilegacy/keycloak
+keycloakConfigCli:
+  image:
+    repository: bitnamilegacy/keycloak-config-cli
 production: true
 proxy: edge
 ingress:
@@ -27,12 +37,19 @@ metrics:
         sourceLabels: [namespace]
         targetLabel: kubernetes_namespace
 postgresql:
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
   primary:
     persistence:
       storageClass: managed-csi-premium
       size: 5Gi
   metrics:
-  enabled: true
+    enabled: true
+    image:
+      repository: bitnamilegacy/postgres-exporter
   serviceMonitor:
     enabled: true
     namespace: keycloak

--- a/clusters/veritable-prod/keycloak/keycloak/values.yaml
+++ b/clusters/veritable-prod/keycloak/keycloak/values.yaml
@@ -37,6 +37,9 @@ metrics:
         sourceLabels: [namespace]
         targetLabel: kubernetes_namespace
 postgresql:
+  global:
+    security:
+      allowInsecureImages: true
   image:
     repository: bitnamilegacy/postgresql
   volumePermissions:

--- a/clusters/veritable-prod/keycloak/nginx/values.yaml
+++ b/clusters/veritable-prod/keycloak/nginx/values.yaml
@@ -1,3 +1,13 @@
+# https://github.com/bitnami/charts/blob/main/bitnami/nginx-ingress-controller/values.yaml
+# Bitnami Legacy image
+global:
+  security:
+    allowInsecureImages: true
+image:
+  repository: bitnamilegacy/nginx-ingress-controller
+defaultBackend:
+  image:
+    repository: bitnamilegacy/nginx
 watchIngressWithoutClass: true
 scope:
   enabled: true

--- a/clusters/veritable-prod/monitoring/nginx/values.yaml
+++ b/clusters/veritable-prod/monitoring/nginx/values.yaml
@@ -1,3 +1,13 @@
+# https://github.com/bitnami/charts/blob/main/bitnami/nginx-ingress-controller/values.yaml
+# Bitnami Legacy image
+global:
+  security:
+    allowInsecureImages: true
+image:
+  repository: bitnamilegacy/nginx-ingress-controller
+defaultBackend:
+  image:
+    repository: bitnamilegacy/nginx
 watchIngressWithoutClass: true
 scope:
   enabled: true


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore

## Linked tickets

VR-415

## High level description

This PR swaps out the subscription-based Bitnami images for the legacy versions. Around two weeks ago, Bitnami decided to end all on-going support for the open-source images that it used to release based on its own Helm chart library. We've several dependencies that rely on Bitnami components directly and others that use [bitnami/postgresql](https://hub.docker.com/r/bitnami/postgresql) via a sub-chart. These are referenced as repositories within Docker Hub and all need to point instead at the corresponding legacy image, for example: [bitnamilegacy/postgresql](https://hub.docker.com/r/bitnamilegacy/postgresql).

More detail on Bitnami's end-of-life decision for its FOSS images can be found here: [35164](https://github.com/bitnami/charts/issues/35164).

These changes are just for production.

## Operational impact

In addition to the change to the Docker Hub repository, we also need to allow the use of "insecure" images.

Where there's a Bitnami chart used directly, `global.security.allowInsecureImages` should be set at the root of the YAML file:

```yaml
global:
  security:
    allowInsecureImages: true
```

Elsewhere, it should be applied to the PostgreSQL chart via `postgresql.global.security.allowInsecureImages`:

```yaml
postgresql:
  global:
    security:
      allowInsecureImages: true
```