### PR TITLE
Use cert-manager chart in Kind

### DIFF
--- a/clusters/kind-cluster/base/app-sync.yaml
+++ b/clusters/kind-cluster/base/app-sync.yaml
@@ -70,6 +70,25 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: cert-manager-sync
+  namespace: cert-manager
+spec:
+  interval: 1m
+  path: ./clusters/kind-cluster/cert-manager/
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+      kind: HelmRelease
+      name: cert-manager
+      namespace: cert-manager
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: keycloak-sync
   namespace: keycloak
 spec:

--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: test/use_first_party_cert_manager_chart
   url: https://github.com/digicatapult/veritable-flux-infra.git
 
 ---

--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: test/use_first_party_cert_manager_chart
+    branch: main
   url: https://github.com/digicatapult/veritable-flux-infra.git
 
 ---

--- a/clusters/kind-cluster/base/namespaces.yaml
+++ b/clusters/kind-cluster/base/namespaces.yaml
@@ -37,3 +37,11 @@ metadata:
   labels:
     app.kubernetes.io/component: monitoring
     pod-security.kubernetes.io/enforce: privileged
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+  labels:
+    app.kubernetes.io/component: cert-manager
+    pod-security.kubernetes.io/enforce: privileged

--- a/clusters/kind-cluster/cert-manager/kustomization.yaml
+++ b/clusters/kind-cluster/cert-manager/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cert-manager 
+resources:
+  - source.yaml
+  - release.yaml
+configMapGenerator:
+  - name: cert-manager-values
+    files:
+      - values.yaml=values.yaml
+configurations:
+  - kustomize-config.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/clusters/kind-cluster/cert-manager/kustomize-config.yaml
+++ b/clusters/kind-cluster/cert-manager/kustomize-config.yaml
@@ -1,0 +1,7 @@
+---
+nameReference:
+- kind: ConfigMap
+  version: v1
+  fieldSpecs:
+  - path: spec/valuesFrom/name
+    kind: HelmRelease

--- a/clusters/kind-cluster/cert-manager/release.yaml
+++ b/clusters/kind-cluster/cert-manager/release.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: cert-manager 
+  namespace: cert-manager
+spec:
+  install:
+    remediation:
+      retries: -1
+  releaseName: cert-manager
+  chart:
+    spec:
+      version: 1.18.2
+      chart: cert-manager
+      sourceRef:
+        kind: HelmRepository
+        name: cert-manager
+  interval: 10m0s
+  # Default values
+  # https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
+  valuesFrom:
+    - kind: ConfigMap
+      name: cert-manager-values
+      valuesKey: values.yaml

--- a/clusters/kind-cluster/cert-manager/source.yaml
+++ b/clusters/kind-cluster/cert-manager/source.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+spec:
+  interval: 10m
+  url: https://charts.jetstack.io

--- a/clusters/kind-cluster/cert-manager/values.yaml
+++ b/clusters/kind-cluster/cert-manager/values.yaml
@@ -1,3 +1,4 @@
+# https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
 crds:
   keep: true
   enabled: true

--- a/clusters/kind-cluster/cert-manager/values.yaml
+++ b/clusters/kind-cluster/cert-manager/values.yaml
@@ -2,7 +2,7 @@ crds:
   keep: true
   enabled: true
 prometheus:
-  serviceMonitor:
+  servicemonitor:
     enabled: true
     namespace: cert-manager
     targetPort: http

--- a/clusters/kind-cluster/cert-manager/values.yaml
+++ b/clusters/kind-cluster/cert-manager/values.yaml
@@ -6,4 +6,9 @@ prometheus:
   servicemonitor:
     enabled: true
     namespace: cert-manager
-    targetPort: http
+    targetPort: 9402
+    endpointAdditionalProperties:
+      relabelings:
+      - action: replace
+        sourceLabels: [namespace]
+        targetLabel: kubernetes_namespace

--- a/clusters/kind-cluster/cert-manager/values.yaml
+++ b/clusters/kind-cluster/cert-manager/values.yaml
@@ -1,0 +1,8 @@
+crds:
+  keep: true
+  enabled: true
+prometheus:
+  serviceMonitor:
+    enabled: true
+    namespace: cert-manager
+    targetPort: http


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Feature

## Linked tickets

ENG-186; VR-444

## High level description

Though we don't need cert-manager in the Kind environment, this ticket is to demonstrate the installation of one of the replacement charts that we'll be needing to completely remove [bitnami/cert-manager](https://github.com/bitnami/charts/tree/main/bitnami/cert-manager) in production.