### PR TITLE
Set package rules to use negative globs

### DIFF
--- a/renovate.config.js
+++ b/renovate.config.js
@@ -37,7 +37,9 @@ module.exports = (config = {}) => {
         matchManagers: ["flux"],
         matchFileNames: [
           "clusters/kind-cluster/**/*.yaml",
-          "clusters/kind-cluster/**/*.yml"
+          "clusters/kind-cluster/**/*.yml",
+          "clusters/veritable-prod/**/!*.yaml",
+          "clusters/veritable-prod/**/!*.yml",
         ],
         postUpgradeTasks: {
           fileFilters: [
@@ -56,7 +58,9 @@ module.exports = (config = {}) => {
         matchManagers: ["flux"],
         matchFileNames: [
           "clusters/veritable-prod/**/*.yaml",
-          "clusters/veritable-prod/**/*.yml"
+          "clusters/veritable-prod/**/*.yml",
+          "clusters/kind-cluster/**/!*.yaml",
+          "clusters/kind-cluster/**/!*.yml",
         ],
         postUpgradeTasks: {
           fileFilters: [


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix
- [x] Chore

## Linked tickets

ENG-183

## High level description

Our existing package rules match on all YAML found for both clusters without distinction, even though we've been attempting to set unique behaviour for each directory path. To try and rectify this issue, I've used negative globs here in an attempt to match against the path we _don't_ want to include. The negative glob pattern (`**/!*.yaml`) has been tested separately and `matchFileNames` should support it, i.e. negative globs are permitted.

With the Kind rule, for example, it should match all YAML on the `kind-cluster` path and exclude all YAML from `veritable-prod`.