### PR TITLE
Set tags for PostgreSQL sub-charts

### DIFF
--- a/clusters/kind-cluster/alice/veritable-cloudagent/release.yaml
+++ b/clusters/kind-cluster/alice/veritable-cloudagent/release.yaml
@@ -17,7 +17,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: digicatapult
-      version: 2.4.16
+      version: 2.4.27
   valuesFrom:
   - kind: ConfigMap
     name: alice-values

--- a/clusters/kind-cluster/alice/veritable-cloudagent/values.yaml
+++ b/clusters/kind-cluster/alice/veritable-cloudagent/values.yaml
@@ -17,11 +17,13 @@ postgresql:
   volumePermissions:
     image:
       repository: bitnamilegacy/os-shell
+      tag: 12-debian-12-r50
   auth:
     password: postgres
   metrics:
     image:
       repository: bitnamilegacy/postgres-exporter
+      tag: 0.17.1-debian-12-r14
     enabled: true
     serviceMonitor:
       enabled: true

--- a/clusters/kind-cluster/alice/veritable-cloudagent/values.yaml
+++ b/clusters/kind-cluster/alice/veritable-cloudagent/values.yaml
@@ -13,6 +13,7 @@ postgresql:
       allowInsecureImages: true
   image:
     repository: bitnamilegacy/postgresql
+    tag: 17.5.0-debian-12-r9
   volumePermissions:
     image:
       repository: bitnamilegacy/os-shell

--- a/clusters/kind-cluster/alice/veritable-ui/release.yaml
+++ b/clusters/kind-cluster/alice/veritable-ui/release.yaml
@@ -18,7 +18,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: digicatapult
-      version: 1.3.5
+      version: 1.3.4
   interval: 10m0s
   valuesFrom:
     - kind: ConfigMap

--- a/clusters/kind-cluster/alice/veritable-ui/release.yaml
+++ b/clusters/kind-cluster/alice/veritable-ui/release.yaml
@@ -18,7 +18,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: digicatapult
-      version: 1.1.37
+      version: 1.3.5
   interval: 10m0s
   valuesFrom:
     - kind: ConfigMap

--- a/clusters/kind-cluster/alice/veritable-ui/release.yaml
+++ b/clusters/kind-cluster/alice/veritable-ui/release.yaml
@@ -18,7 +18,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: digicatapult
-      version: 1.3.4
+      version: 1.3.5
   interval: 10m0s
   valuesFrom:
     - kind: ConfigMap

--- a/clusters/kind-cluster/alice/veritable-ui/values.yaml
+++ b/clusters/kind-cluster/alice/veritable-ui/values.yaml
@@ -27,6 +27,7 @@ postgresql:
       allowInsecureImages: true
   image:
     repository: bitnamilegacy/postgresql
+    tag: 17.5.0-debian-12-r9
   volumePermissions:
     image:
       repository: bitnamilegacy/os-shell

--- a/clusters/kind-cluster/alice/veritable-ui/values.yaml
+++ b/clusters/kind-cluster/alice/veritable-ui/values.yaml
@@ -31,11 +31,13 @@ postgresql:
   volumePermissions:
     image:
       repository: bitnamilegacy/os-shell
+      tag: 12-debian-12-r50
   auth:
     password: postgres
   metrics:
     image:
       repository: bitnamilegacy/postgres-exporter
+      tag: 0.17.1-debian-12-r14
     enabled: true
     serviceMonitor:
       enabled: true

--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: test/checkout_latest_ui_version
   url: https://github.com/digicatapult/veritable-flux-infra.git
 
 ---

--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: test/checkout_latest_ui_version
+    branch: main
   url: https://github.com/digicatapult/veritable-flux-infra.git
 
 ---

--- a/clusters/kind-cluster/bob/veritable-cloudagent/release.yaml
+++ b/clusters/kind-cluster/bob/veritable-cloudagent/release.yaml
@@ -17,7 +17,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: digicatapult
-      version: 2.4.16
+      version: 2.4.27
   valuesFrom:
   - kind: ConfigMap
     name: bob-values

--- a/clusters/kind-cluster/bob/veritable-cloudagent/values.yaml
+++ b/clusters/kind-cluster/bob/veritable-cloudagent/values.yaml
@@ -17,11 +17,13 @@ postgresql:
   volumePermissions:
     image:
       repository: bitnamilegacy/os-shell
+      tag: 12-debian-12-r50
   auth:
     password: postgres
   metrics:
     image:
       repository: bitnamilegacy/postgres-exporter
+      tag: 0.17.1-debian-12-r14
     enabled: true
     serviceMonitor:
       enabled: true

--- a/clusters/kind-cluster/bob/veritable-cloudagent/values.yaml
+++ b/clusters/kind-cluster/bob/veritable-cloudagent/values.yaml
@@ -13,6 +13,7 @@ postgresql:
       allowInsecureImages: true
   image:
     repository: bitnamilegacy/postgresql
+    tag: 17.5.0-debian-12-r9
   volumePermissions:
     image:
       repository: bitnamilegacy/os-shell

--- a/clusters/kind-cluster/charlie/veritable-cloudagent/release.yaml
+++ b/clusters/kind-cluster/charlie/veritable-cloudagent/release.yaml
@@ -17,7 +17,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: digicatapult
-      version: 2.4.16
+      version: 2.4.27
   valuesFrom:
   - kind: ConfigMap
     name: charlie-values

--- a/clusters/kind-cluster/charlie/veritable-cloudagent/values.yaml
+++ b/clusters/kind-cluster/charlie/veritable-cloudagent/values.yaml
@@ -17,11 +17,13 @@ postgresql:
   volumePermissions:
     image:
       repository: bitnamilegacy/os-shell
+      tag: 12-debian-12-r50
   auth:
     password: postgres
   metrics:
     image:
       repository: bitnamilegacy/postgres-exporter
+      tag: 0.17.1-debian-12-r14
     enabled: true
     serviceMonitor:
       enabled: true

--- a/clusters/kind-cluster/charlie/veritable-cloudagent/values.yaml
+++ b/clusters/kind-cluster/charlie/veritable-cloudagent/values.yaml
@@ -13,6 +13,7 @@ postgresql:
       allowInsecureImages: true
   image:
     repository: bitnamilegacy/postgresql
+    tag: 17.5.0-debian-12-r9
   volumePermissions:
     image:
       repository: bitnamilegacy/os-shell

--- a/clusters/kind-cluster/keycloak/values.yaml
+++ b/clusters/kind-cluster/keycloak/values.yaml
@@ -18,6 +18,7 @@ ingress:
 postgresql:
   image:
     repository: bitnamilegacy/postgresql
+    tag: 17.5.0-debian-12-r9
   volumePermissions:
     image:
       repository: bitnamilegacy/os-shell

--- a/clusters/kind-cluster/keycloak/values.yaml
+++ b/clusters/kind-cluster/keycloak/values.yaml
@@ -22,9 +22,11 @@ postgresql:
   volumePermissions:
     image:
       repository: bitnamilegacy/os-shell
+      tag: 12-debian-12-r50
   metrics:
     image:
       repository: bitnamilegacy/postgres-exporter
+      tag: 0.17.1-debian-12-r14
   auth:
     password: postgres
 extraEnvVars:


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix
- [x] Chore

## High level description

Our sub-charts still track the tags for images that are now only available from the subscription-only Bitnami repository. That is currently breaking Kind deployments, which attempt to retrieve PostgreSQL v17.6 from the Bitnami legacy repository even though it's unavailable; it is only available from the private repository. To fix this issue while we work to remove Bitnami components more generally, we need to be adding legacy image tags to prevent the sub-charts from breaking.