### PR TITLE
Replace bitnami/keycloak in Kind

### DIFF
--- a/clusters/kind-cluster/alice/veritable-ui/values.yaml
+++ b/clusters/kind-cluster/alice/veritable-ui/values.yaml
@@ -4,7 +4,7 @@ apiSwaggerTitle: Alice
 apiSwaggerBgColor: "#38b6ff"
 idpClientId: "alice"
 idpPublicURLPrefix: http://localhost:3080/auth2/realms/simple/protocol/openid-connect
-idpInternalURLPrefix: http://keycloak.keycloak.svc.cluster.local/auth2/realms/simple/protocol/openid-connect
+idpInternalURLPrefix: http://keycloak-http.keycloak.svc.cluster.local/auth2/realms/simple/protocol/openid-connect
 externalCloudagent:
   host: "alice-veritable-cloudagent-admin.alice.svc.cluster.local"
   port: "3000"

--- a/clusters/kind-cluster/base/app-sync.yaml
+++ b/clusters/kind-cluster/base/app-sync.yaml
@@ -70,6 +70,34 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: cloudnative-pg-sync
+  namespace: keycloak
+spec:
+  interval: 1m
+  path: ./clusters/kind-cluster/keycloak/cloudnative-pg
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-sync
+  namespace: keycloak
+spec:
+  interval: 1m
+  path: ./clusters/kind-cluster/keycloak/cluster
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: keycloak-sync
   namespace: keycloak
 spec:

--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: feature/replace_bitnami_keycloak_with_codecentric
   url: https://github.com/digicatapult/veritable-flux-infra.git
 
 ---

--- a/clusters/kind-cluster/keycloak/cloudnative-pg/kustomization.yaml
+++ b/clusters/kind-cluster/keycloak/cloudnative-pg/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: keycloak
+resources:
+  - release.yaml
+configMapGenerator:
+  - name: cloudnative-pg-values
+    files:
+      - values.yaml=values.yaml
+configurations:
+  - kustomize-config.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/clusters/kind-cluster/keycloak/cloudnative-pg/kustomize-config.yaml
+++ b/clusters/kind-cluster/keycloak/cloudnative-pg/kustomize-config.yaml
@@ -1,0 +1,7 @@
+---
+nameReference:
+- kind: ConfigMap
+  version: v1
+  fieldSpecs:
+  - path: spec/valuesFrom/name
+    kind: HelmRelease

--- a/clusters/kind-cluster/keycloak/cloudnative-pg/release.yaml
+++ b/clusters/kind-cluster/keycloak/cloudnative-pg/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
-  name: keycloak
+  name: cloudnative-pg
   namespace: keycloak
 spec:
   install:
@@ -10,16 +10,16 @@ spec:
   upgrade:
     remediation:
       retries: -1
-  releaseName: keycloak
+  releaseName: cloudnative-pg
   chart:
     spec:
-      chart: keycloakx
+      chart: cloudnative-pg
       sourceRef:
         kind: HelmRepository
-        name: codecentric
-      version: "7.1.1"
+        name: cloudnative-pg
+      version: "0.25.0"
   interval: 10m0s
   valuesFrom:
     - kind: ConfigMap
-      name: keycloak-values
+      name: cloudnative-pg-values
       valuesKey: values.yaml

--- a/clusters/kind-cluster/keycloak/cloudnative-pg/values.yaml
+++ b/clusters/kind-cluster/keycloak/cloudnative-pg/values.yaml
@@ -1,0 +1,3 @@
+# https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg/values.yaml
+crds:
+  create: true

--- a/clusters/kind-cluster/keycloak/cluster/database.yaml
+++ b/clusters/kind-cluster/keycloak/cluster/database.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: postgresql
+  namespace: keycloak
+spec:
+  name: bitnami_keycloak
+  owner: bn_keycloak
+  cluster:
+    name: postgresql-cluster
+  databaseReclaimPolicy: delete
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: keycloak
+  namespace: keycloak
+spec:
+  name: keycloak
+  owner: keycloak
+  cluster:
+    name: postgresql-cluster
+  databaseReclaimPolicy: delete
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-cluster
+spec:
+  instances: 1
+  storage:
+    size: 8Gi
+  managed:
+    roles:
+    - name: app
+      createdb: true
+      login: true
+    - name: keycloak
+      ensure: present
+      login: true
+      superuser: false
+      createdb: true
+      createrole: true
+      inherit: false
+      replication: false
+      bypassrls: false
+      connectionLimit: 4
+      validUntil: "2050-01-01T00:00:00Z"
+      inRoles:
+        - pg_monitor
+        - pg_signal_backend
+      passwordSecret:
+        name: postgresql-role-secret
+    - name: bn_keycloak
+      ensure: present
+      login: true
+      superuser: false
+      createdb: true
+      createrole: true
+      inherit: false
+      replication: false
+      bypassrls: false
+      connectionLimit: 4
+      validUntil: "2050-01-01T00:00:00Z"
+      inRoles:
+        - pg_monitor
+        - pg_signal_backend
+      passwordSecret:
+        name: postgresql-bitnami-keycloak-secret
+---
+apiVersion: v1
+data:
+  username: a2V5Y2xvYWs=
+  password: a2V5Y2xvYWs=
+kind: Secret
+metadata:
+  name: postgresql-role-secret
+  namespace: keycloak
+type: kubernetes.io/basic-auth
+---
+apiVersion: v1
+data:
+  username: Ym5fa2V5Y2xvYWs=
+  password: a2V5Y2xvYWs=
+kind: Secret
+metadata:
+  name: postgresql-bitnami-keycloak-secret
+  namespace: keycloak
+type: kubernetes.io/basic-auth

--- a/clusters/kind-cluster/keycloak/cluster/kustomization.yaml
+++ b/clusters/kind-cluster/keycloak/cluster/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: keycloak
+resources:
+  - database.yaml
+  - release.yaml
+configMapGenerator:
+  - name: cluster-values
+    files:
+      - values.yaml=values.yaml
+configurations:
+  - kustomize-config.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/clusters/kind-cluster/keycloak/cluster/kustomize-config.yaml
+++ b/clusters/kind-cluster/keycloak/cluster/kustomize-config.yaml
@@ -1,0 +1,7 @@
+---
+nameReference:
+- kind: ConfigMap
+  version: v1
+  fieldSpecs:
+  - path: spec/valuesFrom/name
+    kind: HelmRelease

--- a/clusters/kind-cluster/keycloak/cluster/release.yaml
+++ b/clusters/kind-cluster/keycloak/cluster/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
-  name: keycloak
+  name: postgresql
   namespace: keycloak
 spec:
   install:
@@ -10,16 +10,16 @@ spec:
   upgrade:
     remediation:
       retries: -1
-  releaseName: keycloak
+  releaseName: postgresql
   chart:
     spec:
-      chart: keycloakx
+      chart: cluster
       sourceRef:
         kind: HelmRepository
-        name: codecentric
-      version: "7.1.1"
+        name: cloudnative-pg
+      version: "0.3.1"
   interval: 10m0s
   valuesFrom:
     - kind: ConfigMap
-      name: keycloak-values
+      name: cluster-values
       valuesKey: values.yaml

--- a/clusters/kind-cluster/keycloak/cluster/values.yaml
+++ b/clusters/kind-cluster/keycloak/cluster/values.yaml
@@ -1,0 +1,9 @@
+# https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/values.yaml
+type: postgresql
+mode: standalone
+version:
+  postgresql: "17.4"
+cluster:
+  instances: 1
+backups:
+  enabled: false

--- a/clusters/kind-cluster/keycloak/source.yaml
+++ b/clusters/kind-cluster/keycloak/source.yaml
@@ -16,3 +16,21 @@ spec:
   type: "oci"
   interval: 10m
   url: oci://registry-1.docker.io/bitnamicharts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: codecentric
+  namespace: keycloak
+spec:
+  interval: 10m
+  url: https://codecentric.github.io/helm-charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: cloudnative-pg
+  namespace: keycloak
+spec:
+  interval: 10m
+  url: https://cloudnative-pg.github.io/charts

--- a/clusters/kind-cluster/keycloak/values.yaml
+++ b/clusters/kind-cluster/keycloak/values.yaml
@@ -1,47 +1,46 @@
-# https://github.com/bitnami/charts/blob/main/bitnami/keycloak/values.yaml
-# Bitnami Legacy images
-global:
-  security:
-    allowInsecureImages: true
-image:
-  repository: bitnamilegacy/keycloak
-keycloakConfigCli:
-  image:
-    repository: bitnamilegacy/keycloak-config-cli
-httpRelativePath: /auth2/
-proxyHeaders: xforwarded
+nameOverride: "keycloak"
+http:
+  relativePath: /auth2
+proxy:
+  enabled: true
+  mode: xforwarded
 ingress:
   enabled: true
-  hostname: localhost
-# https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
-# Bitnami Legacy images
-postgresql:
-  image:
-    repository: bitnamilegacy/postgresql
-  volumePermissions:
-    image:
-      repository: bitnamilegacy/os-shell
-  metrics:
-    image:
-      repository: bitnamilegacy/postgres-exporter
-  auth:
-    password: postgres
-extraEnvVars:
+  servicePort: http
+  annotations: {
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+  }
+database:
+  vendor: postgres
+  hostname: postgresql-cluster-rw.keycloak.svc.cluster.local
+  port: 5432
+  database: keycloak
+  username: keycloak
+  password: keycloak
+extraEnv: |
+  - name: KC_BOOTSTRAP_ADMIN_USERNAME
+    value: admin
+  - name: KC_BOOTSTRAP_ADMIN_PASSWORD
+    value: admin
   - name: KC_HOSTNAME_ADMIN
     value: "http://localhost:3080/auth2/"
   - name: KC_HOSTNAME
     value: "http://localhost:3080/auth2/"
   - name: KC_HOSTNAME_DEBUG
     value: "true"
-extraStartupArgs: "--import-realm"
-extraVolumes:
+  - name: JAVA_OPTS_APPEND
+    value: >-
+      -Djgroups.dns.query={{ include "keycloak.fullname" . }}-headless
+args:
+  - "start-dev"
+  - "--import-realm"
+  - "--hostname-strict=false"
+  - "--verbose"
+extraVolumes: |
   - name: realm-volume
     configMap:
       name: keycloak-realms
       namespace: keycloak
-extraVolumeMounts:
-  - mountPath: /opt/bitnami/keycloak/data/import
+extraVolumeMounts: |
+  - mountPath: /opt/keycloak/data/import
     name: realm-volume
-resourcesPreset: none
-logging:
-  level: DEBUG


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Feature
- [x] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

VR-445

## High level description

In July 2025, Bitnami announced that they'd be discontinuing all public image releases for their Helm chart library. That shift requires us to replace all Bitnami components in charts and sub-charts. This PR is to replace the bitnami/keycloak chart with codecentric/keycloakx; both are built on the Quarkus versions of Keycloak and they're largely similar in structure. One important distinction is that Bitnami included their own PostgreSQL chart as their default database, something the CodeCentric chart doesn't have. To rectify this, I've used the CloudNative-PG charts to provide the CRDs needed and a minimal PostgreSQL cluster that showcases two databases.

## Additional context

Production-grade PostgreSQL operators would benefit from scheduled back-ups, additional replicas, and improved security, but given the nature of Kind as a local environment, these features haven't been demonstrated for the sake of brevity.