### PR TITLE
Disable service monitor due to missing CRDs

### DIFF
--- a/clusters/kind-cluster/cert-manager/values.yaml
+++ b/clusters/kind-cluster/cert-manager/values.yaml
@@ -4,7 +4,7 @@ crds:
   enabled: true
 prometheus:
   servicemonitor:
-    enabled: true
+    enabled: false
     namespace: cert-manager
     targetPort: 9402
     endpointAdditionalProperties:


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## High level description

Normally, we have a monitoring stack dependent on cert-manager's own CRDs. However, if `.prometheus.servicemonitor.enabled` is true, then cert-manager will wait on Prometheus CRDs to be created. This results in timeouts in CI within the Kind environment and the looping will never resolve without manual intervention.