### PR TITLE
Comment out production rule

### DIFF
--- a/renovate.config.js
+++ b/renovate.config.js
@@ -54,27 +54,29 @@ module.exports = (config = {}) => {
         automerge: true,
         addLabels: ["automerge", "kind"],
       },
-      {
-        matchManagers: ["flux"],
-        matchFileNames: [
-          "clusters/veritable-prod/**/*.yaml",
-          "clusters/veritable-prod/**/*.yml",
-          "clusters/kind-cluster/**/!*.yaml",
-          "clusters/kind-cluster/**/!*.yml",
-        ],
-        postUpgradeTasks: {
-          fileFilters: [
-            "clusters/veritable-prod/**/*.yaml",
-            "clusters/veritable-prod/**/*.yml"
-          ]
-        },
-        separateMajorMinor: true,
-        separateMultipleMajor: true,
-        separateMinorPatch: false,
-        groupName: null,
-        automerge: false,
-        addLabels: ["production"],
-      },
+      // Issue: These rules still merge YAML across directories into a single commit
+      // TODO: Investigate how to force the separation of Renovate's PRs by directory
+      // {
+      //   matchManagers: ["flux"],
+      //   matchFileNames: [
+      //     "clusters/veritable-prod/**/*.yaml",
+      //     "clusters/veritable-prod/**/*.yml",
+      //     "clusters/kind-cluster/**/!*.yaml",
+      //     "clusters/kind-cluster/**/!*.yml",
+      //   ],
+      //   postUpgradeTasks: {
+      //     fileFilters: [
+      //       "clusters/veritable-prod/**/*.yaml",
+      //       "clusters/veritable-prod/**/*.yml"
+      //     ]
+      //   },
+      //   separateMajorMinor: true,
+      //   separateMultipleMajor: true,
+      //   separateMinorPatch: false,
+      //   groupName: null,
+      //   automerge: false,
+      //   addLabels: ["production"],
+      // },
       {
         matchManagers: ["github-actions"],
         labels: ["dependencies", "github-actions"],


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

ENG-183

## High level description

There's an on-going issue with the existing configuration, where Renovate identifies an update for a given package and assimilates the affected YAML from across different directories into a single commit. This occurs even with explicit patterns that match against specific directories. These patterns have been tested separately and are known to capture the target files.

Grouping with `groupName` appeared to work to some extent, insofar as it kept the directories distinct, but it meant that all updates for the Kind and production clusters were bundled into just two commits, with one each. That increases the risk of a PR failing because of a single update and becomes difficult to properly triage.

Negative globbing with `/**/!*.yaml` appears to have had no effect whatsoever.

In the documentation, it reads as though `fileFilters` can constrain what's included in the final commit, but that's been tried here to no avail.

## Describe alternatives you've considered

A discussion with the Renovate team was opened a few months back, but there weren't any viable solutions.

## Operational impact

In the immediate term, the Renovate PRs ought to be safer to triage as there's no risk of an accidental merge directly affecting the production environment.

To update the production cluster against what's subsequently working in Kind, we'll need to create PRs that bundle the updates at a suitable cadence.