### PR TITLE
Set Flux manager patterns to include only Kind

### DIFF
--- a/renovate.config.js
+++ b/renovate.config.js
@@ -21,7 +21,10 @@ module.exports = (config = {}) => {
     prConcurrentLimit: 20,
     recreateWhen: "always",
     flux: {
-      managerFilePatterns: ["**/*.yaml", "**/*.yml"],
+      managerFilePatterns: [
+        "clusters/kind-cluster/**/*.yaml",
+        "clusters/kind-cluster/**/*.yml",
+      ],
       labels: ["dependencies", "flux"],
     },
     packageRules: [


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

SQNC-212

## High level description

Since the Flux manager is still capturing the production cluster's YAML files, we need amend its pattern to glob only the Kind cluster directory.