### PR TITLE
Use K8s ingress-nginx chart on production

### DIFF
--- a/clusters/veritable-prod/alice/nginx/release.yaml
+++ b/clusters/veritable-prod/alice/nginx/release.yaml
@@ -8,17 +8,20 @@ spec:
   install:
     remediation:
       retries: -1
-  releaseName: nginx-ingress-controller
+  upgrade:
+    remediation:
+      retries: -1
+  releaseName: ingress-nginx
   chart:
     spec:
-      version: 11.6.12
-      chart: nginx-ingress-controller
+      chart: ingress-nginx
       sourceRef:
         kind: HelmRepository
-        name: bitnami-oci
-  interval: 10m0s
+        name: ingress-nginx
+      version: "4.13.2"
+  interval: 10m
   # Default values
-  # https://github.com/bitnami/charts/blob/master/bitnami/nginx-ingress-controller/values.yaml
+  # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   valuesFrom:
     - kind: ConfigMap
       name: alice-values

--- a/clusters/veritable-prod/alice/nginx/values.yaml
+++ b/clusters/veritable-prod/alice/nginx/values.yaml
@@ -1,42 +1,34 @@
-# https://github.com/bitnami/charts/blob/main/bitnami/nginx-ingress-controller/values.yaml
-# Bitnami Legacy image
-global:
-  security:
-    allowInsecureImages: true
-image:
-  repository: bitnamilegacy/nginx-ingress-controller
-defaultBackend:
-  image:
-    repository: bitnamilegacy/nginx
-watchIngressWithoutClass: true
-scope:
-  enabled: true
-ingressClassResource:
-  name: nginx-alice
-  default: false
-service:
-  type: LoadBalancer
-  annotations: 
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
-    external-dns.alpha.kubernetes.io/hostname: alice.vrtbl.com
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    cert-manager.io/common-name: alice.vrtbl.com
-extraArgs:
-  default-ssl-certificate: "alice/alice-vrtbl-com-prod-tls"
-nodeSelector:
-  kubernetes.io/os: linux
-tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Equal
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
-    operator: Equal
-containerPorts:
-  http: 80
-  https: 443
-metrics:
-  enabled: true
-  serviceMonitor:
+# https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
+controller:
+  watchIngressWithoutClass: true
+  scope:
     enabled: true
-    namespace: alice
+  ingressClassResource:
+    name: nginx-alice
+    default: false
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+      external-dns.alpha.kubernetes.io/hostname: alice.vrtbl.com
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      cert-manager.io/common-name: alice.vrtbl.com
+  extraArgs:
+    default-ssl-certificate: "alice/alice-vrtbl-com-prod-tls"
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Equal
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Equal
+  containerPort:
+    http: 80
+    https: 443
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      namespace: alice

--- a/clusters/veritable-prod/alice/source.yaml
+++ b/clusters/veritable-prod/alice/source.yaml
@@ -25,3 +25,12 @@ spec:
   type: "oci"
   interval: 10m
   url: oci://registry-1.docker.io/bitnamicharts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: alice
+spec:
+  interval: 10m
+  url: https://kubernetes.github.io/ingress-nginx

--- a/clusters/veritable-prod/base/flux-system/gotk-sync.yaml
+++ b/clusters/veritable-prod/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: chore/add_ingress_nginx_chart_to_production
+    branch: main
   url: https://github.com/digicatapult/veritable-flux-infra.git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/clusters/veritable-prod/base/flux-system/gotk-sync.yaml
+++ b/clusters/veritable-prod/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: chore/add_ingress_nginx_chart_to_production
   url: https://github.com/digicatapult/veritable-flux-infra.git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/clusters/veritable-prod/bob/nginx/release.yaml
+++ b/clusters/veritable-prod/bob/nginx/release.yaml
@@ -8,17 +8,20 @@ spec:
   install:
     remediation:
       retries: -1
-  releaseName: nginx-ingress-controller
+  upgrade:
+    remediation:
+      retries: -1
+  releaseName: ingress-nginx
   chart:
     spec:
-      version: 11.6.12
-      chart: nginx-ingress-controller
+      chart: ingress-nginx
       sourceRef:
         kind: HelmRepository
-        name: bitnami-oci
-  interval: 10m0s
+        name: ingress-nginx
+      version: "4.13.2"
+  interval: 10m
   # Default values
-  # https://github.com/bitnami/charts/blob/master/bitnami/nginx-ingress-controller/values.yaml
+  # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   valuesFrom:
     - kind: ConfigMap
       name: bob-values

--- a/clusters/veritable-prod/bob/nginx/values.yaml
+++ b/clusters/veritable-prod/bob/nginx/values.yaml
@@ -1,42 +1,34 @@
-# https://github.com/bitnami/charts/blob/main/bitnami/nginx-ingress-controller/values.yaml
-# Bitnami Legacy image
-global:
-  security:
-    allowInsecureImages: true
-image:
-  repository: bitnamilegacy/nginx-ingress-controller
-defaultBackend:
-  image:
-    repository: bitnamilegacy/nginx
-watchIngressWithoutClass: true
-scope:
-  enabled: true
-ingressClassResource:
-  name: nginx-bob
-  default: false
-service:
-  type: LoadBalancer
-  annotations: 
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
-    external-dns.alpha.kubernetes.io/hostname: bob.vrtbl.com
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    cert-manager.io/common-name: bob.vrtbl.com
-extraArgs:
-  default-ssl-certificate: "bob/bob-vrtbl-com-prod-tls"
-nodeSelector:
-  kubernetes.io/os: linux
-tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Equal
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
-    operator: Equal
-containerPorts:
-  http: 80
-  https: 443
-metrics:
-  enabled: true
-  serviceMonitor:
+# https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
+controller:
+  watchIngressWithoutClass: true
+  scope:
     enabled: true
-    namespace: bob
+  ingressClassResource:
+    name: nginx-bob
+    default: false
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+      external-dns.alpha.kubernetes.io/hostname: bob.vrtbl.com
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      cert-manager.io/common-name: bob.vrtbl.com
+  extraArgs:
+    default-ssl-certificate: "bob/bob-vrtbl-com-prod-tls"
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Equal
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Equal
+  containerPort:
+    http: 80
+    https: 443
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      namespace: bob

--- a/clusters/veritable-prod/bob/source.yaml
+++ b/clusters/veritable-prod/bob/source.yaml
@@ -25,3 +25,12 @@ spec:
   type: "oci"
   interval: 10m
   url: oci://registry-1.docker.io/bitnamicharts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: bob
+spec:
+  interval: 10m
+  url: https://kubernetes.github.io/ingress-nginx

--- a/clusters/veritable-prod/charlie/nginx/release.yaml
+++ b/clusters/veritable-prod/charlie/nginx/release.yaml
@@ -8,17 +8,20 @@ spec:
   install:
     remediation:
       retries: -1
-  releaseName: nginx-ingress-controller
+  upgrade:
+    remediation:
+      retries: -1
+  releaseName: ingress-nginx
   chart:
     spec:
-      version: 11.6.12
-      chart: nginx-ingress-controller
+      chart: ingress-nginx
       sourceRef:
         kind: HelmRepository
-        name: bitnami-oci
-  interval: 10m0s
+        name: ingress-nginx
+      version: "4.13.2"
+  interval: 10m
   # Default values
-  # https://github.com/bitnami/charts/blob/master/bitnami/nginx-ingress-controller/values.yaml
+  # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   valuesFrom:
     - kind: ConfigMap
       name: charlie-values

--- a/clusters/veritable-prod/charlie/nginx/values.yaml
+++ b/clusters/veritable-prod/charlie/nginx/values.yaml
@@ -1,42 +1,34 @@
-# https://github.com/bitnami/charts/blob/main/bitnami/nginx-ingress-controller/values.yaml
-# Bitnami Legacy image
-global:
-  security:
-    allowInsecureImages: true
-image:
-  repository: bitnamilegacy/nginx-ingress-controller
-defaultBackend:
-  image:
-    repository: bitnamilegacy/nginx
-watchIngressWithoutClass: true
-scope:
-  enabled: true
-ingressClassResource:
-  name: nginx-charlie
-  default: false
-service:
-  type: LoadBalancer
-  annotations: 
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
-    external-dns.alpha.kubernetes.io/hostname: charlie.vrtbl.com
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    cert-manager.io/common-name: charlie.vrtbl.com
-extraArgs:
-  default-ssl-certificate: "charlie/charlie-vrtbl-com-prod-tls"
-nodeSelector:
-  kubernetes.io/os: linux
-tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Equal
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
-    operator: Equal
-containerPorts:
-  http: 80
-  https: 443
-metrics:
-  enabled: true
-  serviceMonitor:
+# https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
+controller:
+  watchIngressWithoutClass: true
+  scope:
     enabled: true
-    namespace: charlie
+  ingressClassResource:
+    name: nginx-charlie
+    default: false
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+      external-dns.alpha.kubernetes.io/hostname: charlie.vrtbl.com
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      cert-manager.io/common-name: charlie.vrtbl.com
+  extraArgs:
+    default-ssl-certificate: "charlie/charlie-vrtbl-com-prod-tls"
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Equal
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Equal
+  containerPort:
+    http: 80
+    https: 443
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      namespace: charlie

--- a/clusters/veritable-prod/charlie/source.yaml
+++ b/clusters/veritable-prod/charlie/source.yaml
@@ -25,3 +25,12 @@ spec:
   type: "oci"
   interval: 10m
   url: oci://registry-1.docker.io/bitnamicharts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: charlie
+spec:
+  interval: 10m
+  url: https://kubernetes.github.io/ingress-nginx

--- a/clusters/veritable-prod/dave/nginx/release.yaml
+++ b/clusters/veritable-prod/dave/nginx/release.yaml
@@ -8,17 +8,20 @@ spec:
   install:
     remediation:
       retries: -1
-  releaseName: nginx-ingress-controller
+  upgrade:
+    remediation:
+      retries: -1
+  releaseName: ingress-nginx
   chart:
     spec:
-      version: 11.6.12
-      chart: nginx-ingress-controller
+      chart: ingress-nginx
       sourceRef:
         kind: HelmRepository
-        name: bitnami-oci
-  interval: 10m0s
+        name: ingress-nginx
+      version: "4.13.2"
+  interval: 10m
   # Default values
-  # https://github.com/bitnami/charts/blob/master/bitnami/nginx-ingress-controller/values.yaml
+  # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   valuesFrom:
     - kind: ConfigMap
       name: dave-values

--- a/clusters/veritable-prod/dave/nginx/values.yaml
+++ b/clusters/veritable-prod/dave/nginx/values.yaml
@@ -1,42 +1,34 @@
-# https://github.com/bitnami/charts/blob/main/bitnami/nginx-ingress-controller/values.yaml
-# Bitnami Legacy image
-global:
-  security:
-    allowInsecureImages: true
-image:
-  repository: bitnamilegacy/nginx-ingress-controller
-defaultBackend:
-  image:
-    repository: bitnamilegacy/nginx
-watchIngressWithoutClass: true
-scope:
-  enabled: true
-ingressClassResource:
-  name: nginx-dave
-  default: false
-service:
-  type: LoadBalancer
-  annotations: 
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
-    external-dns.alpha.kubernetes.io/hostname: dave.vrtbl.com
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    cert-manager.io/common-name: dave.vrtbl.com
-extraArgs:
-  default-ssl-certificate: "dave/dave-vrtbl-com-prod-tls"
-nodeSelector:
-  kubernetes.io/os: linux
-tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Equal
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
-    operator: Equal
-containerPorts:
-  http: 80
-  https: 443
-metrics:
-  enabled: true
-  serviceMonitor:
+# https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
+controller:
+  watchIngressWithoutClass: true
+  scope:
     enabled: true
-    namespace: dave
+  ingressClassResource:
+    name: nginx-dave
+    default: false
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+      external-dns.alpha.kubernetes.io/hostname: dave.vrtbl.com
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      cert-manager.io/common-name: dave.vrtbl.com
+  extraArgs:
+    default-ssl-certificate: "dave/dave-vrtbl-com-prod-tls"
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Equal
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Equal
+  containerPort:
+    http: 80
+    https: 443
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      namespace: dave

--- a/clusters/veritable-prod/dave/source.yaml
+++ b/clusters/veritable-prod/dave/source.yaml
@@ -25,3 +25,12 @@ spec:
   type: "oci"
   interval: 10m
   url: oci://registry-1.docker.io/bitnamicharts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: dave
+spec:
+  interval: 10m
+  url: https://kubernetes.github.io/ingress-nginx

--- a/clusters/veritable-prod/eve/nginx/release.yaml
+++ b/clusters/veritable-prod/eve/nginx/release.yaml
@@ -8,17 +8,20 @@ spec:
   install:
     remediation:
       retries: -1
-  releaseName: nginx-ingress-controller
+  upgrade:
+    remediation:
+      retries: -1
+  releaseName: ingress-nginx
   chart:
     spec:
-      version: 11.6.12
-      chart: nginx-ingress-controller
+      chart: ingress-nginx
       sourceRef:
         kind: HelmRepository
-        name: bitnami-oci
-  interval: 10m0s
+        name: ingress-nginx
+      version: "4.13.2"
+  interval: 10m
   # Default values
-  # https://github.com/bitnami/charts/blob/master/bitnami/nginx-ingress-controller/values.yaml
+  # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   valuesFrom:
     - kind: ConfigMap
       name: eve-values

--- a/clusters/veritable-prod/eve/nginx/values.yaml
+++ b/clusters/veritable-prod/eve/nginx/values.yaml
@@ -1,42 +1,34 @@
-# https://github.com/bitnami/charts/blob/main/bitnami/nginx-ingress-controller/values.yaml
-# Bitnami Legacy image
-global:
-  security:
-    allowInsecureImages: true
-image:
-  repository: bitnamilegacy/nginx-ingress-controller
-defaultBackend:
-  image:
-    repository: bitnamilegacy/nginx
-watchIngressWithoutClass: true
-scope:
-  enabled: true
-ingressClassResource:
-  name: nginx-eve
-  default: false
-service:
-  type: LoadBalancer
-  annotations: 
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
-    external-dns.alpha.kubernetes.io/hostname: eve.vrtbl.com
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    cert-manager.io/common-name: eve.vrtbl.com
-extraArgs:
-  default-ssl-certificate: "eve/eve-vrtbl-com-prod-tls"
-nodeSelector:
-  kubernetes.io/os: linux
-tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Equal
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
-    operator: Equal
-containerPorts:
-  http: 80
-  https: 443
-metrics:
-  enabled: true
-  serviceMonitor:
+# https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
+controller:
+  watchIngressWithoutClass: true
+  scope:
     enabled: true
-    namespace: eve
+  ingressClassResource:
+    name: nginx-eve
+    default: false
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+      external-dns.alpha.kubernetes.io/hostname: eve.vrtbl.com
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      cert-manager.io/common-name: eve.vrtbl.com
+  extraArgs:
+    default-ssl-certificate: "eve/eve-vrtbl-com-prod-tls"
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Equal
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Equal
+  containerPort:
+    http: 80
+    https: 443
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      namespace: eve

--- a/clusters/veritable-prod/eve/source.yaml
+++ b/clusters/veritable-prod/eve/source.yaml
@@ -25,3 +25,12 @@ spec:
   type: "oci"
   interval: 10m
   url: oci://registry-1.docker.io/bitnamicharts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: eve
+spec:
+  interval: 10m
+  url: https://kubernetes.github.io/ingress-nginx

--- a/clusters/veritable-prod/keycloak/nginx/release.yaml
+++ b/clusters/veritable-prod/keycloak/nginx/release.yaml
@@ -8,17 +8,20 @@ spec:
   install:
     remediation:
       retries: -1
-  releaseName: nginx-ingress-controller
+  upgrade:
+    remediation:
+      retries: -1
+  releaseName: ingress-nginx
   chart:
     spec:
-      version: 11.6.12
-      chart: nginx-ingress-controller
+      chart: ingress-nginx
       sourceRef:
         kind: HelmRepository
-        name: bitnami-oci
-  interval: 10m0s
+        name: ingress-nginx
+      version: "4.13.2"
+  interval: 10m
   # Default values
-  # https://github.com/bitnami/charts/blob/master/bitnami/nginx-ingress-controller/values.yaml
+  # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   valuesFrom:
     - kind: ConfigMap
       name: keycloak-values

--- a/clusters/veritable-prod/keycloak/nginx/values.yaml
+++ b/clusters/veritable-prod/keycloak/nginx/values.yaml
@@ -1,46 +1,38 @@
-# https://github.com/bitnami/charts/blob/main/bitnami/nginx-ingress-controller/values.yaml
-# Bitnami Legacy image
-global:
-  security:
-    allowInsecureImages: true
-image:
-  repository: bitnamilegacy/nginx-ingress-controller
-defaultBackend:
-  image:
-    repository: bitnamilegacy/nginx
-watchIngressWithoutClass: true
-scope:
-  enabled: true
-ingressClassResource:
-  name: nginx-keycloak
-  default: false
-service:
-  type: LoadBalancer
-  annotations: 
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
-    external-dns.alpha.kubernetes.io/hostname: auth.vrtbl.com
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    cert-manager.io/common-name: auth.vrtbl.com
-extraArgs:
-  default-ssl-certificate: "keycloak/auth-vrtbl-com-prod-tls"
-nodeSelector:
-  kubernetes.io/os: linux
-tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Equal
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
-    operator: Equal
-containerPorts:
-  http: 80
-  https: 443
-metrics:
-  enabled: true
-  serviceMonitor:
+# https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
+controller:
+  watchIngressWithoutClass: true
+  scope:
     enabled: true
-    namespace: keycloak
-    relabelings:
-      - action: replace
-        sourceLabels: [namespace]
-        targetLabel: kubernetes_namespace
+  ingressClassResource:
+    name: nginx-keycloak
+    default: false
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+      external-dns.alpha.kubernetes.io/hostname: auth.vrtbl.com
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      cert-manager.io/common-name: auth.vrtbl.com
+  extraArgs:
+    default-ssl-certificate: "keycloak/auth-vrtbl-com-prod-tls"
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Equal
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Equal
+  containerPort:
+    http: 80
+    https: 443
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      namespace: keycloak
+      relabelings:
+        - action: replace
+          sourceLabels: [namespace]
+          targetLabel: kubernetes_namespace

--- a/clusters/veritable-prod/keycloak/source.yaml
+++ b/clusters/veritable-prod/keycloak/source.yaml
@@ -25,3 +25,12 @@ metadata:
 spec:
   interval: 10m
   url: https://codecentric.github.io/helm-charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: keycloak
+spec:
+  interval: 10m
+  url: https://kubernetes.github.io/ingress-nginx

--- a/clusters/veritable-prod/monitoring/nginx/release.yaml
+++ b/clusters/veritable-prod/monitoring/nginx/release.yaml
@@ -8,17 +8,20 @@ spec:
   install:
     remediation:
       retries: -1
-  releaseName: nginx-ingress-controller
+  upgrade:
+    remediation:
+      retries: -1
+  releaseName: ingress-nginx
   chart:
     spec:
-      version: 11.6.12
-      chart: nginx-ingress-controller
+      chart: ingress-nginx
       sourceRef:
         kind: HelmRepository
-        name: bitnami-oci
+        name: ingress-nginx
+      version: "4.13.2"
   interval: 10m
   # Default values
-  # https://github.com/bitnami/charts/blob/master/bitnami/nginx-ingress-controller/values.yaml
+  # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   valuesFrom:
     - kind: ConfigMap
       name: monitoring-values

--- a/clusters/veritable-prod/monitoring/nginx/values.yaml
+++ b/clusters/veritable-prod/monitoring/nginx/values.yaml
@@ -1,46 +1,38 @@
-# https://github.com/bitnami/charts/blob/main/bitnami/nginx-ingress-controller/values.yaml
-# Bitnami Legacy image
-global:
-  security:
-    allowInsecureImages: true
-image:
-  repository: bitnamilegacy/nginx-ingress-controller
-defaultBackend:
-  image:
-    repository: bitnamilegacy/nginx
-watchIngressWithoutClass: true
-scope:
-  enabled: true
-ingressClassResource:
-  name: nginx-monitoring
-  default: false
-service:
-  type: LoadBalancer
-  annotations: 
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
-    external-dns.alpha.kubernetes.io/hostname: monitoring.vrtbl.com
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    cert-manager.io/common-name: monitoring.vrtbl.com
-extraArgs:
-  default-ssl-certificate: "monitoring/monitoring-vrtbl-com-prod-tls"
-nodeSelector:
-  kubernetes.io/os: linux
-tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Equal
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
-    operator: Equal
-containerPorts:
-  http: 80
-  https: 443
-metrics:
-  enabled: true
-  serviceMonitor:
+# https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
+controller:
+  watchIngressWithoutClass: true
+  scope:
     enabled: true
-    namespace: monitoring
-    relabelings:
-      - action: replace
-        sourceLabels: [namespace]
-        targetLabel: kubernetes_namespace
+  ingressClassResource:
+    name: nginx-monitoring
+    default: false
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+      external-dns.alpha.kubernetes.io/hostname: monitoring.vrtbl.com
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      cert-manager.io/common-name: monitoring.vrtbl.com
+  extraArgs:
+    default-ssl-certificate: "monitoring/monitoring-vrtbl-com-prod-tls"
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Equal
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Equal
+  containerPort:
+    http: 80
+    https: 443
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      namespace: monitoring
+      relabelings:
+        - action: replace
+          sourceLabels: [namespace]
+          targetLabel: kubernetes_namespace

--- a/clusters/veritable-prod/monitoring/source.yaml
+++ b/clusters/veritable-prod/monitoring/source.yaml
@@ -17,3 +17,12 @@ spec:
   type: "oci"
   interval: 10m
   url: oci://registry-1.docker.io/bitnamicharts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: monitoring
+spec:
+  interval: 10m
+  url: https://kubernetes.github.io/ingress-nginx


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix
- [x] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

VR-453

## High level description

As part of the broader move away from Bitnami's charts to avoid its impending suspension of public image releases, this request will essentially just swap out the existing configuration for the Kubernetes community's own [ingress-chart](https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx).

## Detailed description

All of the configuration in the existing chart is mirrored within its replacement, with few exceptions:

- All root level fields are indented under `controller` in the ingress-nginx chart
- `containerPorts` instead becomes `containerPort` with ingress-nginx

There are seven affected namespaces in the production environment, each with their own specific ingress resource:

- monitoring
- keycloak
- eve
- dave
- charlie
- bob
- alice

Chart replacements will be replicated across all of them, one after another.