### PR TITLE
Add CNPG external cluster to Veritable apps

### DIFF
--- a/clusters/veritable-prod/base/flux-system/gotk-sync.yaml
+++ b/clusters/veritable-prod/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: chore/add_cnpg_cluster_to_veritable_apps
   url: https://github.com/digicatapult/veritable-flux-infra.git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/clusters/veritable-prod/eve/cloudagent/cluster/cluster.yaml
+++ b/clusters/veritable-prod/eve/cloudagent/cluster/cluster.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cloudagent-cnpg
+  namespace: eve
+spec:
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.4
+  instances: 1
+  storage:
+    size: 5Gi
+    storageClass: managed-csi-premium
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: eve-cloudagent-cnpg-superuser-creds
+  bootstrap:
+    initdb:
+      database: walletId
+      owner: cloudagent
+      secret:
+        name: eve-cloudagent-cnpg-creds
+      import:
+        type: microservice
+        databases:
+          - walletId
+        source:
+          externalCluster: cloudagent-postgresql
+  externalClusters:
+    - name: cloudagent-postgresql
+      connectionParameters:
+        host: cloudagent-postgresql.eve.svc.cluster.local
+        port: "5432"
+        user: postgres
+        dbname: postgres
+      password:
+        name: cloudagent-postgresql
+        key: postgres-password

--- a/clusters/veritable-prod/eve/cloudagent/cluster/kustomization.yaml
+++ b/clusters/veritable-prod/eve/cloudagent/cluster/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cluster
-  - release.yaml
+  - cluster.yaml

--- a/clusters/veritable-prod/eve/cloudagent/release.yaml
+++ b/clusters/veritable-prod/eve/cloudagent/release.yaml
@@ -27,7 +27,3 @@ spec:
       name: eve-wallet-key
       valuesKey: key
       targetPath: walletKey.secret
-    - kind: Secret
-      name: eve-cloudagent-postgres-creds
-      valuesKey: password
-      targetPath: postgresql.auth.password

--- a/clusters/veritable-prod/eve/cloudagent/values.yaml
+++ b/clusters/veritable-prod/eve/cloudagent/values.yaml
@@ -3,28 +3,17 @@ endpoint: "http://cloudagent-veritable-cloudagent.eve.svc.cluster.local:5002"
 logLevel: trace
 ingress:
   enabled: false
-# https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
-# Bitnami Legacy images
 postgresql:
-  global:
-    security:
-      allowInsecureImages: true
-  image:
-    repository: bitnamilegacy/postgresql
-  volumePermissions:
-    image:
-      repository: bitnamilegacy/os-shell
-  primary:
-    persistence:
-      storageClass: managed-csi-premium
-      size: 5Gi
-  metrics:
-    enabled: true
-    image:
-      repository: bitnamilegacy/postgres-exporter
-    serviceMonitor:
-      enabled: true
-      namespace: eve
+  enabled: false
+externalDatabase:
+  create: false
+  host: cloudagent-cnpg-rw.eve.svc.cluster.local
+  port: 5432
+  user: cloudagent
+  database: walletId
+  existingSecret: eve-cloudagent-cnpg-creds
+  existingSecretPasswordKey: password
+  existingSecretPostgresPasswordKey: pgpass
 ipfs:
   persistence:
     size: 5Gi

--- a/clusters/veritable-prod/secrets/eve-cloudagent-cnpg-creds.yaml
+++ b/clusters/veritable-prod/secrets/eve-cloudagent-cnpg-creds.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:DZOQr1KkmZr8cng0OcDpsw==,iv:Gp6dByWiWUuyeGz2b/VMKMpaK/qI9SbL/iO9l/CPH9A=,tag:/JkflWVsYcb+dhE+yz+jbQ==,type:str]
+    pgpass: ENC[AES256_GCM,data:2xPCC69xHzXa96d64AWJ2A==,iv:8hMIwHpYJdZCurJN9WTHpJOewQXJJ1jltqLI3tYJ9kY=,tag:NQ7qVBtVhnNlFS7MAftYPQ==,type:str]
+    postgres-password: ENC[AES256_GCM,data:aDJ3iJ6Jh5Sv/lcHGgV/9g==,iv:eZWosRExOxREIoGjdh1tEZiljHmpnpsA/tB7kaSCb+o=,tag:wqfj4e/3wBwWecP17U9pBg==,type:str]
+    username: ENC[AES256_GCM,data:YDGlCLXibhGZyZbymtyCzA==,iv:EYJinPIeLYD0QOLy4yghDHV+IgqSMBIZVCz2DwgJt1Q=,tag:4T1AMAvAoNUrk2JP8rR7kA==,type:str]
+kind: Secret
+metadata:
+    name: eve-cloudagent-cnpg-creds
+    namespace: eve
+    labels:
+        cnpg.io/reload: "true"
+sops:
+    lastmodified: "2025-10-08T10:31:07Z"
+    mac: ENC[AES256_GCM,data:mPv33raYc/YtWSPO6P0HT85fOwV3ZQYYrPDRmpIzLlgyGsvFD1UKgDiZqwUTudlA3qhSB03gaCGkPwib2WPG2GcC1iuPfbyeymEhujxBt6mUAmlCXvqtkI3H8LvX85XfQGhNC7c8HgCZzQ5imgaxVy3Liumclq96AgoTZmOYX5Q=,iv:iClBaifLGFm3/q6/iSdImS7EgdI02I03Bp60qc/lS4A=,tag:Dq1UTFc7nBv+ubNtCK8pMA==,type:str]
+    pgp:
+        - created_at: "2025-10-08T10:31:07Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4Dnkn8tt10QEQSAQdAjAKSfqFl87/PGyMhyxctREiIpGA2p3mAsZt5gVdHqTkw
+            jBT6Pd0zrbEmg1fRvyh/6whiMZ3Do0Cs/DodJRQMAzBY6ddYNJAt17+ebo59EGl9
+            1GgBCQIQa92V/rbgGFxhbzI+oSzzdu6WBzw8+xHSBVT0DbAdED1/H+RW4lIUtvqe
+            z/CyQ9GDq2rCLWRLBk+5JGsqwg3Gf5SSoTrVGrjRm5VlNbsdR6xTYLX9fLJ27qjD
+            LsWEYjTJVKQkyg==
+            =eUw5
+            -----END PGP MESSAGE-----
+          fp: 4A6351B3CE46129AA516AF77DAF4C53DA4A9B16C
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/clusters/veritable-prod/secrets/eve-cloudagent-cnpg-superuser-creds.yaml
+++ b/clusters/veritable-prod/secrets/eve-cloudagent-cnpg-superuser-creds.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:aqTorK0i0CAkEMUwCQNkvw==,iv:6al9KPDlD0Pr5z1VhKAv28a+/BG71WhdLxlRt9WcaVI=,tag:X30pVRECofW4AYUkwAeOtQ==,type:str]
+    pgpass: ENC[AES256_GCM,data:A7zIdVtgpRvEYdD3cnNtFA==,iv:6IHiP1RQcFhVUOvl2q6ozK7DxVxBJs3xQuNACJobwKE=,tag:vG/+ur5eh7/MQmKEa1qfYw==,type:str]
+    postgres-password: ENC[AES256_GCM,data:Lb6sQfpJGjMoOsrZLwHAZA==,iv:a0EwML0XRyOMdzfd553dOPttFLdePzIRkcsDV/rEHes=,tag:ttjY+z6PToQhiGKSIvdjnQ==,type:str]
+    username: ENC[AES256_GCM,data:aa4CalAyrsc0hP2K,iv:q7LVIjVQVcEqwlu5wVI/KBbVcAE2sWQukyfxh3mhA84=,tag:1/qEP2ydSCsn+Y+sC6zcJw==,type:str]
+kind: Secret
+metadata:
+    name: eve-cloudagent-cnpg-superuser-creds
+    namespace: eve
+    labels:
+        cnpg.io/reload: "true"
+sops:
+    lastmodified: "2025-10-08T10:31:07Z"
+    mac: ENC[AES256_GCM,data:f4wK9Ebqxt3gaBUA+PLvrWKkUJl+7WH4AfeaQ6ICTqzFC3wi1s5PZQxlQa+0dZi7WXlvM5LQ6dTYdnkFW72B7N/sNbeb+myvXjZcqtReVR2m/F52qsjvVDL6wthNJRAkC3YrJu53KhSVn4lJSkmnFuapBBcx6TwSKAD+PANal+8=,iv:nKcLumZGVGreVrGxuEAefSNoKrIznw7kKMkuFb7y7Bw=,tag:41nQrf6FlGJVsL22RFGbtg==,type:str]
+    pgp:
+        - created_at: "2025-10-08T10:31:07Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4Dnkn8tt10QEQSAQdA8T4bq0sprtML9n5yoQLa2YyWkQYGSSVkrt8Yn2DgRHsw
+            Ci5NL8xt6+04palivHXC2bJgwEbaeKx20J2qDAb2o4N6L3JO0yDSdIVeWpEn1Qoa
+            1GYBCQIQDUkLWrLKaB+45H5ZrRDuiFeYnc4eEJeCy2A2mI7lhz9ER8lfFUY7Y5K1
+            7nT8PH5rMM7cyWdsVij+D8ACKl35vlcnK8z0MUu/vDy3BKKsK0g8dTatu8wUMzLx
+            8VDBiK7URBM=
+            =7E6Z
+            -----END PGP MESSAGE-----
+          fp: 4A6351B3CE46129AA516AF77DAF4C53DA4A9B16C
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore

## Linked tickets

VR-471

## High level description

This PR is to create new CNPG clusters, to replace the Bitnami PostgreSQL ones that currently exist for each cloudagent and UI instance, using `.bootstrap.initdb.import` within the CNPG ClusterSpec API to automate the database migration. This has been tried and tested previously with the Keycloak migration, and the process here is identical.